### PR TITLE
refactor: move entire XML formatting functionality into XmlFormat.Lib

### DIFF
--- a/XmlFormat.Lib/XmlFormat.cs
+++ b/XmlFormat.Lib/XmlFormat.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Text;
+using TurboXml;
+
+namespace XmlFormat;
+
+public static class XmlFormat
+{
+    public static void Format(Stream inputStream, Stream outputStream)
+    {
+        using var handler = new FormattingXmlReadHandler(
+            stream: outputStream,
+            encoding: Encoding.UTF8
+        );
+        XmlParser.Parse(inputStream, handler);
+    }
+
+    public static string Format(string xml)
+    {
+        using Stream xmlStream = new MemoryStream(Encoding.UTF8.GetBytes(xml) ?? new byte[0]);
+        using Stream outStream = new MemoryStream();
+        Format(inputStream: xmlStream, outputStream: outStream);
+        return outStream.ToString() ?? "";
+    }
+}

--- a/XmlFormat.Tool/Program.cs
+++ b/XmlFormat.Tool/Program.cs
@@ -32,8 +32,7 @@ public class Program
 
         using var istream = OpenInputStreamOrStdIn(options);
         using var ostream = OpenOutputStreamOrStdOut(options);
-        using var handler = new FormattingXmlReadHandler(stream: ostream, encoding: Encoding.UTF8);
-        XmlParser.Parse(istream, handler);
+        XmlFormat.Format(istream, ostream);
     }
 
     static void HandleParseError(IEnumerable<Error> errs)


### PR DESCRIPTION
- **feat(lib): implement static wrapper function to call XmlParser.Parse() with FormattingXmlReadHandler**
- **refactor(tool): call wrapper function instead of XmlParser.Parse()**
