### PR TITLE
build: set package metadata for XmlFormat projects

### DIFF
--- a/XmlFormat.Lib/XmlFormat.Lib.csproj
+++ b/XmlFormat.Lib/XmlFormat.Lib.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/XmlFormat.Lib/XmlFormat.Lib.csproj
+++ b/XmlFormat.Lib/XmlFormat.Lib.csproj
@@ -11,6 +11,7 @@
     <PackageId>KageKirin.XmlFormat</PackageId>
     <Title>XmlFormat (lib)</Title>
     <Description>Library for formatting XML data</Description>
+    <PackageTags>xml;formatting</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/XmlFormat.Lib/XmlFormat.Lib.csproj
+++ b/XmlFormat.Lib/XmlFormat.Lib.csproj
@@ -7,6 +7,10 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Label="build metadata">
+    <PackageId>KageKirin.XmlFormat</PackageId>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="TurboXml" />
   </ItemGroup>

--- a/XmlFormat.Lib/XmlFormat.Lib.csproj
+++ b/XmlFormat.Lib/XmlFormat.Lib.csproj
@@ -10,6 +10,7 @@
   <PropertyGroup Label="build metadata">
     <PackageId>KageKirin.XmlFormat</PackageId>
     <Title>XmlFormat (lib)</Title>
+    <Description>Library for formatting XML data</Description>
   </PropertyGroup>
 
   <ItemGroup>

--- a/XmlFormat.Lib/XmlFormat.Lib.csproj
+++ b/XmlFormat.Lib/XmlFormat.Lib.csproj
@@ -12,6 +12,8 @@
     <Title>XmlFormat (lib)</Title>
     <Description>Library for formatting XML data</Description>
     <PackageTags>xml;formatting</PackageTags>
+    <PackageIcon>Icon.png</PackageIcon>
+    <PackageIconUrl>https://raw.github.com/KageKirin/XmlFormat/main/Icon.png</PackageIconUrl>
   </PropertyGroup>
 
   <ItemGroup>

--- a/XmlFormat.Lib/XmlFormat.Lib.csproj
+++ b/XmlFormat.Lib/XmlFormat.Lib.csproj
@@ -9,6 +9,7 @@
 
   <PropertyGroup Label="build metadata">
     <PackageId>KageKirin.XmlFormat</PackageId>
+    <Title>XmlFormat (lib)</Title>
   </PropertyGroup>
 
   <ItemGroup>

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup Label="build metadata">
     <PackageId>KageKirin.XmlFormat.Tool</PackageId>
     <Title>XmlFormat</Title>
-    <Description>XML formatting tool</Description>
+    <Description>CLI tool for formatting XML files</Description>
     <PackageTags>xml;formatting</PackageTags>
     <PackageIcon>Icon.png</PackageIcon>
     <PackageIconUrl>https://raw.github.com/KageKirin/XmlFormat/main/Icon.png</PackageIconUrl>


### PR DESCRIPTION
- **build: set flag IsPackable to true for XmlFormat.Lib project**
- **build: set package Id to 'KageKirin.XmlFormat.Lib' for XmlFormat.Lib project**
- **build: set package Title for XmlFormat.Lib project**
- **build: set package Description for XmlFormat.Lib project**
- **build: set package tags for XmlFormat.Lib project**
- **build: set package icon for XmlFormat.Lib project**
- **build: improve package Description for XmlFormat.Tool project**
