### PR TITLE
refactor: split Element tokenizer into Element Start/Empty and Element End

### DIFF
--- a/Tests/SAX.Tokenizer.Test/NegativeTokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/NegativeTokenizerTests.cs
@@ -80,135 +80,171 @@ public class NegativeTokenizerTest
     [Fact]
     public void NegativeTestElementNoAttributes()
     {
-        Assert.False(TestHelper.Tokenize("<element/", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("<element ", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("<element\n", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("<element\n /", [XmlTokenizer.XmlToken.Element]));
+        Assert.False(TestHelper.Tokenize("<element/", [XmlTokenizer.XmlToken.ElementStartOrEmpty]));
+        Assert.False(TestHelper.Tokenize("<element ", [XmlTokenizer.XmlToken.ElementStartOrEmpty]));
+        Assert.False(
+            TestHelper.Tokenize("<element\n", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.False(
+            TestHelper.Tokenize("<element\n /", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
 
-        Assert.False(TestHelper.Tokenize("<element", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("<element ", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("<element\n", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("<element\n ", [XmlTokenizer.XmlToken.Element]));
+        Assert.False(TestHelper.Tokenize("<element", [XmlTokenizer.XmlToken.ElementStartOrEmpty]));
+        Assert.False(TestHelper.Tokenize("<element ", [XmlTokenizer.XmlToken.ElementStartOrEmpty]));
+        Assert.False(
+            TestHelper.Tokenize("<element\n", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.False(
+            TestHelper.Tokenize("<element\n ", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
 
-        Assert.False(TestHelper.Tokenize("</element", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("</element ", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("</element\n", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("</element\n ", [XmlTokenizer.XmlToken.Element]));
+        Assert.False(TestHelper.Tokenize("</element", [XmlTokenizer.XmlToken.ElementEnd]));
+        Assert.False(TestHelper.Tokenize("</element ", [XmlTokenizer.XmlToken.ElementEnd]));
+        Assert.False(TestHelper.Tokenize("</element\n", [XmlTokenizer.XmlToken.ElementEnd]));
+        Assert.False(TestHelper.Tokenize("</element\n ", [XmlTokenizer.XmlToken.ElementEnd]));
 
-        Assert.False(TestHelper.Tokenize("<el:em_en-t/", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("<el:em_en-t ", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("<el:em_en-t\n/", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("<el:em_en-t\n ", [XmlTokenizer.XmlToken.Element]));
+        Assert.False(
+            TestHelper.Tokenize("<el:em_en-t/", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.False(
+            TestHelper.Tokenize("<el:em_en-t ", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.False(
+            TestHelper.Tokenize("<el:em_en-t\n/", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.False(
+            TestHelper.Tokenize("<el:em_en-t\n ", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
 
-        Assert.False(TestHelper.Tokenize("<el:em_en-t", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("<el:em_en-t ", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("<el:em_en-t\n", [XmlTokenizer.XmlToken.Element]));
-        Assert.False(TestHelper.Tokenize("<el:em_en-t\n ", [XmlTokenizer.XmlToken.Element]));
+        Assert.False(
+            TestHelper.Tokenize("<el:em_en-t", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.False(
+            TestHelper.Tokenize("<el:em_en-t ", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.False(
+            TestHelper.Tokenize("<el:em_en-t\n", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.False(
+            TestHelper.Tokenize("<el:em_en-t\n ", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
 
-        Assert.False(TestHelper.Tokenize("</el:em_en-t", [XmlTokenizer.XmlToken.Element]));
+        Assert.False(TestHelper.Tokenize("</el:em_en-t", [XmlTokenizer.XmlToken.ElementEnd]));
     }
 
     [Fact]
     public void NegativeTestElementWithAttributes()
     {
         Assert.False(
-            TestHelper.Tokenize("<element foobar=\"hogehoge\"/", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"hogehoge\"/",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
         Assert.False(
-            TestHelper.Tokenize("<element foobar=\"hogehoge\" ", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"hogehoge\" ",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
         Assert.False(
-            TestHelper.Tokenize("<element foobar=\"{hogehoge}\" ", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"{hogehoge}\" ",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
         Assert.False(
-            TestHelper.Tokenize("<element foobar=\"{hogehoge}\" /", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"{hogehoge}\" /",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
 
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\" xyz=\"abc\"/",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\" xyz=\"abc\" ",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\"\n/",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\"\n ",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\" xyz=\"abc\" standalone /",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\" xyz=\"abc\" standalone ",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n/",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n ",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\"/",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" ",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\"\n/",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\"\n ",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" standalone/",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" standalone ",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         // commented out b/c `<element / >` does not actually fail as expected
@@ -216,126 +252,138 @@ public class NegativeTokenizerTest
         //Assert.False(
         //    TestHelper.Tokenize(
         //        "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n/ >",
-        //        [XmlTokenizer.XmlToken.Element]
+        //        [XmlTokenizer.XmlToken.ElementStartOrEmpty]
         //    )
         //);
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n ",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.False(
-            TestHelper.Tokenize("<element foobar=\"hogehoge\"", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"hogehoge\"",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
         Assert.False(
-            TestHelper.Tokenize("<element foobar=\"hogehoge\" ", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"hogehoge\" ",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
         Assert.False(
-            TestHelper.Tokenize("<element foobar=\"{hogehoge}\"", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"{hogehoge}\"",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
         Assert.False(
-            TestHelper.Tokenize("<element foobar=\"{hogehoge}\" ", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"{hogehoge}\" ",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
 
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\" xyz=\"abc\"",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\" xyz=\"abc\" ",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\"\n",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" \n",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" standalone",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" standalone ",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone \n",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\"",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" ",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\"\n",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" \n",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" standalone",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" standalone ",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.False(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone \n",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
     }

--- a/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
@@ -85,263 +85,310 @@ public class TokenizerTest
     [Fact]
     public void TestElementNoAttributes()
     {
-        Assert.True(TestHelper.Tokenize("<element/>", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("<element />", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("<element\n/>", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("<element\n />", [XmlTokenizer.XmlToken.Element]));
+        Assert.True(TestHelper.Tokenize("<element/>", [XmlTokenizer.XmlToken.ElementStartOrEmpty]));
+        Assert.True(
+            TestHelper.Tokenize("<element />", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.True(
+            TestHelper.Tokenize("<element\n/>", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.True(
+            TestHelper.Tokenize("<element\n />", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
 
-        Assert.True(TestHelper.Tokenize("<element>", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("<element >", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("<element\n>", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("<element\n >", [XmlTokenizer.XmlToken.Element]));
+        Assert.True(TestHelper.Tokenize("<element>", [XmlTokenizer.XmlToken.ElementStartOrEmpty]));
+        Assert.True(TestHelper.Tokenize("<element >", [XmlTokenizer.XmlToken.ElementStartOrEmpty]));
+        Assert.True(
+            TestHelper.Tokenize("<element\n>", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.True(
+            TestHelper.Tokenize("<element\n >", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
 
-        Assert.True(TestHelper.Tokenize("</element>", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("</element >", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("</element\n>", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("</element\n >", [XmlTokenizer.XmlToken.Element]));
+        Assert.True(TestHelper.Tokenize("</element>", [XmlTokenizer.XmlToken.ElementEnd]));
+        Assert.True(TestHelper.Tokenize("</element >", [XmlTokenizer.XmlToken.ElementEnd]));
+        Assert.True(TestHelper.Tokenize("</element\n>", [XmlTokenizer.XmlToken.ElementEnd]));
+        Assert.True(TestHelper.Tokenize("</element\n >", [XmlTokenizer.XmlToken.ElementEnd]));
 
-        Assert.True(TestHelper.Tokenize("<el:em_en-t/>", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("<el:em_en-t />", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("<el:em_en-t\n/>", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("<el:em_en-t\n />", [XmlTokenizer.XmlToken.Element]));
+        Assert.True(
+            TestHelper.Tokenize("<el:em_en-t/>", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.True(
+            TestHelper.Tokenize("<el:em_en-t />", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.True(
+            TestHelper.Tokenize("<el:em_en-t\n/>", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.True(
+            TestHelper.Tokenize("<el:em_en-t\n />", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
 
-        Assert.True(TestHelper.Tokenize("<el:em_en-t>", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("<el:em_en-t >", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("<el:em_en-t\n>", [XmlTokenizer.XmlToken.Element]));
-        Assert.True(TestHelper.Tokenize("<el:em_en-t\n >", [XmlTokenizer.XmlToken.Element]));
+        Assert.True(
+            TestHelper.Tokenize("<el:em_en-t>", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.True(
+            TestHelper.Tokenize("<el:em_en-t >", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.True(
+            TestHelper.Tokenize("<el:em_en-t\n>", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
+        Assert.True(
+            TestHelper.Tokenize("<el:em_en-t\n >", [XmlTokenizer.XmlToken.ElementStartOrEmpty])
+        );
 
-        Assert.True(TestHelper.Tokenize("</el:em_en-t>", [XmlTokenizer.XmlToken.Element]));
+        Assert.True(TestHelper.Tokenize("</el:em_en-t>", [XmlTokenizer.XmlToken.ElementEnd]));
     }
 
     [Fact]
     public void TestElementWithAttributes()
     {
         Assert.True(
-            TestHelper.Tokenize("<element foobar=\"hogehoge\"/>", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"hogehoge\"/>",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
         Assert.True(
-            TestHelper.Tokenize("<element foobar=\"hogehoge\" />", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"hogehoge\" />",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
         Assert.True(
-            TestHelper.Tokenize("<element foobar=\"{hogehoge}\"/>", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"{hogehoge}\"/>",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" />",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\" xyz=\"abc\"/>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\" xyz=\"abc\" />",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\"\n/>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\"\n />",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\" xyz=\"abc\" standalone/>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\" xyz=\"abc\" standalone />",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n/>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n />",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\"/>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" />",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\"\n/>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\"\n />",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" standalone/>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" standalone />",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n/>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n />",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.True(
-            TestHelper.Tokenize("<element foobar=\"hogehoge\">", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"hogehoge\">",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
         Assert.True(
-            TestHelper.Tokenize("<element foobar=\"hogehoge\" >", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"hogehoge\" >",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
         Assert.True(
-            TestHelper.Tokenize("<element foobar=\"{hogehoge}\">", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"{hogehoge}\">",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
         Assert.True(
-            TestHelper.Tokenize("<element foobar=\"{hogehoge}\" >", [XmlTokenizer.XmlToken.Element])
+            TestHelper.Tokenize(
+                "<element foobar=\"{hogehoge}\" >",
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
+            )
         );
 
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\" xyz=\"abc\">",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\" xyz=\"abc\" >",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\"\n>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" \n>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" standalone>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" standalone >",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone \n>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\">",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" >",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\"\n>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" \n>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
 
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" standalone>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"hogehoge\"   xyz=\"abc\" standalone >",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
         Assert.True(
             TestHelper.Tokenize(
                 "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone \n>",
-                [XmlTokenizer.XmlToken.Element]
+                [XmlTokenizer.XmlToken.ElementStartOrEmpty]
             )
         );
     }

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -76,11 +76,9 @@ public static class XmlTokenizer
         select Unit.Value;
 
     /// <summary>
-    /// token parser for elements
-    /// currently pertaining to opening <element>, closing </element> and empty <element/>
-    /// might get subdivided later
+    /// token parser for opening <element> and empty <element/>
     /// </summary>
-    static TextParser<Unit> XmlElement { get; } =
+    static TextParser<Unit> XmlElementStartOrEmpty { get; } =
         from open in Character.EqualTo('<').Try()
         from identifier in Character
             .LetterOrDigit.Or(Character.EqualTo('/'))
@@ -108,7 +106,7 @@ public static class XmlTokenizer
             .Match(XmlProcessingInstruction, XmlToken.ProcessingInstruction)
             .Match(XmlComment, XmlToken.Comment)
             .Match(XmlCData, XmlToken.CData)
-            .Match(XmlElement, XmlToken.ElementStartOrEmpty)
+            .Match(XmlElementStartOrEmpty, XmlToken.ElementStartOrEmpty)
             .Match(XmlContent, XmlToken.Content)
             .Build();
 }

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -41,6 +41,12 @@ public static class XmlTokenizer
         ElementStartOrEmpty,
 
         /// <summary>
+        /// XML closing </element>
+        /// </summary>
+        [Token(Example = "</element>")]
+        ElementEnd,
+
+        /// <summary>
         /// content text
         /// basically everything not between <>
         /// </summary>

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -96,6 +96,16 @@ public static class XmlTokenizer
         select Unit.Value;
 
     /// <summary>
+    /// token parser for closing </element>
+    /// </summary>
+    static TextParser<Unit> XmlElementEnd { get; } =
+        from open in Span.EqualTo("</").Try()
+        from identifier in Character.LetterOrDigit.AtLeastOnce().Value(Unit.Value).Try()
+        from rest in Character.Except('>').Many().Value(Unit.Value).Try()
+        from close in Character.EqualTo('>')
+        select Unit.Value;
+
+    /// <summary>
     /// token parser for content
     /// </summary>
     static TextParser<Unit> XmlContent { get; } =
@@ -113,6 +123,7 @@ public static class XmlTokenizer
             .Match(XmlComment, XmlToken.Comment)
             .Match(XmlCData, XmlToken.CData)
             .Match(XmlElementStartOrEmpty, XmlToken.ElementStartOrEmpty)
+            .Match(XmlElementEnd, XmlToken.ElementEnd)
             .Match(XmlContent, XmlToken.Content)
             .Build();
 }

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -86,11 +86,7 @@ public static class XmlTokenizer
     /// </summary>
     static TextParser<Unit> XmlElementStartOrEmpty { get; } =
         from open in Character.EqualTo('<').Try()
-        from identifier in Character
-            .LetterOrDigit.Or(Character.EqualTo('/'))
-            .AtLeastOnce()
-            .Value(Unit.Value)
-            .Try()
+        from identifier in Character.LetterOrDigit.AtLeastOnce().Value(Unit.Value).Try()
         from rest in Character.Except('>').Many().Value(Unit.Value).Try()
         from close in Character.EqualTo('>')
         select Unit.Value;

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -35,12 +35,10 @@ public static class XmlTokenizer
         CData,
 
         /// <summary>
-        /// XML element
-        /// currently pertaining to opening <element>, closing </element> and empty <element/>
-        /// might get subdivided later
+        /// XML opening <element> or empty <element/>
         /// </summary>
         [Token(Example = "<element ... />")]
-        Element,
+        ElementStartOrEmpty,
 
         /// <summary>
         /// content text
@@ -110,7 +108,7 @@ public static class XmlTokenizer
             .Match(XmlProcessingInstruction, XmlToken.ProcessingInstruction)
             .Match(XmlComment, XmlToken.Comment)
             .Match(XmlCData, XmlToken.CData)
-            .Match(XmlElement, XmlToken.Element)
+            .Match(XmlElement, XmlToken.ElementStartOrEmpty)
             .Match(XmlContent, XmlToken.Content)
             .Build();
 }


### PR DESCRIPTION
- **refactor: rename XmlToken.Element -> XmlToken.ElementStartOrEmpty**
- **refactor: rename parser XmlTokenizer.XmlElement -> XmlTokenizer.XmlElementStartOrEmpty**
- **feat: add XmlToken.ElementEnd**
- **feat: implement parser XmlTokenizer.XmlElementEnd**
- **refactor: adapt XmlElementStartOrEmpty parser to remove 2nd character `/`**
- **refactor: adapt tokenizer unit tests**
