### PR TITLE
refactor: split ProcessingInstruction tokenizer into XML Declaration and regular Processing Instruction

### DIFF
--- a/Tests/SAX.Tokenizer.Test/NegativeTokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/NegativeTokenizerTests.cs
@@ -11,20 +11,10 @@ public class NegativeTokenizerTest
     [Fact]
     public void NegativeTestProcessingInstruction()
     {
-        Assert.False(TestHelper.Tokenize("<?xml>", [XmlTokenizer.XmlToken.ProcessingInstruction]));
-        Assert.False(TestHelper.Tokenize("<?xml ", [XmlTokenizer.XmlToken.ProcessingInstruction]));
-        Assert.False(
-            TestHelper.Tokenize(
-                "<?xml version=\"1.0\" encoding=\"utf-8\">",
-                [XmlTokenizer.XmlToken.ProcessingInstruction]
-            )
-        );
-        Assert.False(
-            TestHelper.Tokenize(
-                "<?xml version=\"1.0\" encoding=\"utf-8\" ",
-                [XmlTokenizer.XmlToken.ProcessingInstruction]
-            )
-        );
+        Assert.False(TestHelper.Tokenize("<?xml>", [XmlTokenizer.XmlToken.Declaration]));
+        Assert.False(TestHelper.Tokenize("<?xml ", [XmlTokenizer.XmlToken.Declaration]));
+        Assert.False(TestHelper.Tokenize("<?xml version=\"1.0\" encoding=\"utf-8\">", [XmlTokenizer.XmlToken.Declaration]));
+        Assert.False(TestHelper.Tokenize("<?xml version=\"1.0\" encoding=\"utf-8\" ", [XmlTokenizer.XmlToken.Declaration]));
         Assert.False(TestHelper.Tokenize("<?php>", [XmlTokenizer.XmlToken.ProcessingInstruction]));
         Assert.False(TestHelper.Tokenize("<?php ", [XmlTokenizer.XmlToken.ProcessingInstruction]));
     }

--- a/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
@@ -5,10 +5,10 @@ namespace SAX.Tokenizer.Test;
 public class TokenizerTest
 {
     [Theory]
-    [InlineData("<?xml?>", XmlTokenizer.XmlToken.ProcessingInstruction)]
-    [InlineData("<?xml ?>", XmlTokenizer.XmlToken.ProcessingInstruction)]
-    [InlineData("<?xml version=\"1.0\" encoding=\"utf-8\"?>", XmlTokenizer.XmlToken.ProcessingInstruction)]
-    [InlineData("<?xml version=\"1.0\" encoding=\"utf-8\" ?>", XmlTokenizer.XmlToken.ProcessingInstruction)]
+    [InlineData("<?xml?>", XmlTokenizer.XmlToken.Declaration)]
+    [InlineData("<?xml ?>", XmlTokenizer.XmlToken.Declaration)]
+    [InlineData("<?xml version=\"1.0\" encoding=\"utf-8\"?>", XmlTokenizer.XmlToken.Declaration)]
+    [InlineData("<?xml version=\"1.0\" encoding=\"utf-8\" ?>", XmlTokenizer.XmlToken.Declaration)]
     [InlineData("<?php?>", XmlTokenizer.XmlToken.ProcessingInstruction)]
     [InlineData("<?php ?>", XmlTokenizer.XmlToken.ProcessingInstruction)]
     [InlineData(@"<?php print(""hello world"");?>", XmlTokenizer.XmlToken.ProcessingInstruction)]

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -59,6 +59,15 @@ public static class XmlTokenizer
     }
 
     /// <summary>
+    /// token parser for XML Declaration
+    /// </summary>
+    static TextParser<Unit> XmlDeclaration { get; } =
+        from open in Span.EqualTo("<?xml").Try()
+        from rest in Span.Except("?>").Many().Value(Unit.Value).Try()
+        from close in Span.EqualTo("?>").Try()
+        select Unit.Value;
+
+    /// <summary>
     /// token parser for Processing Instructions
     /// </summary>
     static TextParser<Unit> XmlProcessingInstruction { get; } =
@@ -120,6 +129,7 @@ public static class XmlTokenizer
     public static Tokenizer<XmlToken> Instance { get; } =
         new TokenizerBuilder<XmlToken>()
             .Ignore(Span.WhiteSpace)
+            .Match(XmlDeclaration, XmlToken.Declaration)
             .Match(XmlProcessingInstruction, XmlToken.ProcessingInstruction)
             .Match(XmlComment, XmlToken.Comment)
             .Match(XmlCData, XmlToken.CData)

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -14,8 +14,13 @@ public static class XmlTokenizer
     public enum XmlToken
     {
         /// <summary>
+        /// XML declaration, i.e. <?xml ... ?>
+        /// </summary>
+        [Token(Example = "<?xml ... ?>")]
+        Declaration,
+
+        /// <summary>
         /// processing instruction, e.g. <?php ... ?>
-        /// NOTE: we are also considering the regular XML header <?xml ...?> as such
         /// </summary>
         [Token(Example = "<?pi ... ?>")]
         ProcessingInstruction,


### PR DESCRIPTION
- **feat: add XmlToken.Declaration**
- **feat: implement parser XmlTokenizer.XmlDeclaration**
- **refactor: adapt tokenizer unit tests**
