### PR TITLE
feat: implement XML token-specific parsers

### DIFF
--- a/Tests/SAX.TokenParser.Test/CDataParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/CDataParserTest.cs
@@ -1,0 +1,43 @@
+using Superpower.Model;
+using XmlFormat.SAX;
+
+namespace SAX.TokenParser.Test;
+
+public class CDataParserTest
+{
+    [Theory]
+    [InlineData("<![CDATA[]]>")]
+    public void TestEmptyCData(string input)
+    {
+        var result = XmlTokenParser.TrimCData(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var cdata = result.Value;
+        Assert.Empty(cdata.ToStringValue());
+    }
+
+    [Theory]
+    [InlineData("<![CDATA[ ]]>", " ")]
+    [InlineData("<![CDATA[\n]]>", "\n")]
+    [InlineData("<![CDATA[foobar]]>", "foobar")]
+    [InlineData("<![CDATA[foobar ]]>", "foobar ")]
+    [InlineData("<![CDATA[ foobar]]>", " foobar")]
+    [InlineData("<![CDATA[ foobar ]]>", " foobar ")]
+    [InlineData("<![CDATA[\nfoobar\nhoge\n]]>", "\nfoobar\nhoge\n")]
+    [InlineData("<![CDATA[\nfoobar\nhoge\n ]]>", "\nfoobar\nhoge\n ")]
+    [InlineData("<![CDATA[ \nfoobar\nhoge\n]]>", " \nfoobar\nhoge\n")]
+    [InlineData("<![CDATA[ \nfoobar\nhoge\n ]]>", " \nfoobar\nhoge\n ")]
+    public void TestCData(string input, string expected)
+    {
+        var result = XmlTokenParser.TrimCData(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var cdata = result.Value;
+        Assert.NotEmpty(cdata.ToStringValue());
+        Assert.True(cdata.EqualsValue(expected));
+    }
+}

--- a/Tests/SAX.TokenParser.Test/CommentParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/CommentParserTest.cs
@@ -1,0 +1,43 @@
+using Superpower.Model;
+using XmlFormat.SAX;
+
+namespace SAX.TokenParser.Test;
+
+public class CommentParserTest
+{
+    [Theory]
+    [InlineData("<!---->")]
+    public void TestEmptyComment(string input)
+    {
+        var result = XmlTokenParser.TrimComment(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var comment = result.Value;
+        Assert.Empty(comment.ToStringValue());
+    }
+
+    [Theory]
+    [InlineData("<!-- -->", " ")]
+    [InlineData("<!--\n-->", "\n")]
+    [InlineData("<!--comment-->", "comment")]
+    [InlineData("<!--comment -->", "comment ")]
+    [InlineData("<!-- comment-->", " comment")]
+    [InlineData("<!-- comment -->", " comment ")]
+    [InlineData("<!--\ncomment\nmore comment\n-->", "\ncomment\nmore comment\n")]
+    [InlineData("<!--\ncomment\nmore comment\n -->", "\ncomment\nmore comment\n ")]
+    [InlineData("<!-- \ncomment\nmore comment\n-->", " \ncomment\nmore comment\n")]
+    [InlineData("<!-- \ncomment\nmore comment\n -->", " \ncomment\nmore comment\n ")]
+    public void TestComment(string input, string expected)
+    {
+        var result = XmlTokenParser.TrimComment(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var comment = result.Value;
+        Assert.NotEmpty(comment.ToStringValue());
+        Assert.True(comment.EqualsValue(expected));
+    }
+}

--- a/Tests/SAX.TokenParser.Test/ElementAndAttributesParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/ElementAndAttributesParserTest.cs
@@ -1,0 +1,183 @@
+using Superpower.Model;
+using XmlFormat.SAX;
+
+namespace SAX.TokenParser.Test;
+
+public class ElementAndAttributesParserTest
+{
+    [Theory]
+    [InlineData("<element", "element")]
+    [InlineData("<el-ement", "el-ement")]
+    [InlineData("<el_ement", "el_ement")]
+    [InlineData("<el:ement", "el:ement")]
+    [InlineData("<el:em_ent", "el:em_ent")]
+    [InlineData("<el-em_ent", "el-em_ent")]
+    [InlineData("<el:em-ent", "el:em-ent")]
+    [InlineData("<el:em-en_t", "el:em-en_t")]
+    [InlineData("<element1", "element1")]
+    [InlineData("<element ", "element")]
+    [InlineData("<el-ement ", "el-ement")]
+    [InlineData("<el_ement ", "el_ement")]
+    [InlineData("<el:ement ", "el:ement")]
+    [InlineData("<el:em_ent ", "el:em_ent")]
+    [InlineData("<el-em_ent ", "el-em_ent")]
+    [InlineData("<el:em-ent ", "el:em-ent")]
+    [InlineData("<el:em-en_t ", "el:em-en_t")]
+    [InlineData("<element1 ", "element1")]
+    [InlineData("<element\n ", "element")]
+    [InlineData("<el-ement\n ", "el-ement")]
+    [InlineData("<el_ement\n ", "el_ement")]
+    [InlineData("<el:ement\n ", "el:ement")]
+    [InlineData("<el:em_ent\n ", "el:em_ent")]
+    [InlineData("<el-em_ent\n ", "el-em_ent")]
+    [InlineData("<el:em-ent\n ", "el:em-ent")]
+    [InlineData("<el:em-en_t\n ", "el:em-en_t")]
+    [InlineData("<element1\n ", "element1")]
+    public void TestElementAndNoAttributes(string input, string expected)
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expected, element.Identifier.ToStringValue());
+        Assert.Empty(element.Attributes);
+    }
+
+    [Theory]
+    [InlineData("<element attribute", "element", "attribute")]
+    [InlineData("<el-ement at-tribute", "el-ement", "at-tribute")]
+    [InlineData("<el_ement at_tribute", "el_ement", "at_tribute")]
+    [InlineData("<el:ement at:tribute", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent at:tri_bute", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent at-tri_bute", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent at:tri-bute", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t at:tri-but_e", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1 attribute0", "element1", "attribute0")]
+    [InlineData("<element attribute ", "element", "attribute")]
+    [InlineData("<el-ement at-tribute ", "el-ement", "at-tribute")]
+    [InlineData("<el_ement at_tribute ", "el_ement", "at_tribute")]
+    [InlineData("<el:ement at:tribute ", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent at:tri_bute ", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent at-tri_bute ", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent at:tri-bute ", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t at:tri-but_e ", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1 attribute0 ", "element1", "attribute0")]
+    [InlineData("<element\nattribute \n", "element", "attribute")]
+    [InlineData("<el-ement\nat-tribute \n", "el-ement", "at-tribute")]
+    [InlineData("<el_ement\nat_tribute \n", "el_ement", "at_tribute")]
+    [InlineData("<el:ement\nat:tribute \n", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent\nat:tri_bute \n", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent\nat-tri_bute \n", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent\nat:tri-bute \n", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t\nat:tri-but_e \n", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1\nattribute0 \n", "element1", "attribute0")]
+    public void TestElementAndAttributeNoValue(string input, string expectedElement, string expectedAttribute)
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Single(element.Attributes);
+        var attribute = element.Attributes[0];
+        Assert.NotEmpty(attribute.Name.ToStringValue());
+        Assert.Equal(expectedAttribute, attribute.Name.ToStringValue());
+        Assert.Null(attribute.Value);
+    }
+
+    [Theory]
+    [InlineData("<element attribute=\"\"", "element", "attribute")]
+    [InlineData("<el-ement at-tribute=\"\"", "el-ement", "at-tribute")]
+    [InlineData("<el_ement at_tribute=\"\"", "el_ement", "at_tribute")]
+    [InlineData("<el:ement at:tribute=\"\"", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent at:tri_bute=\"\"", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent at-tri_bute=\"\"", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent at:tri-bute=\"\"", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t at:tri-but_e=\"\"", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1 attribute0=\"\"", "element1", "attribute0")]
+    [InlineData("<element attribute=\"\" ", "element", "attribute")]
+    [InlineData("<el-ement at-tribute=\"\" ", "el-ement", "at-tribute")]
+    [InlineData("<el_ement at_tribute=\"\" ", "el_ement", "at_tribute")]
+    [InlineData("<el:ement at:tribute=\"\" ", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent at:tri_bute=\"\" ", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent at-tri_bute=\"\" ", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent at:tri-bute=\"\" ", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t at:tri-but_e=\"\" ", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1 attribute0=\"\" ", "element1", "attribute0")]
+    [InlineData("<element\nattribute=\"\"\n", "element", "attribute")]
+    [InlineData("<el-ement\nat-tribute=\"\"\n", "el-ement", "at-tribute")]
+    [InlineData("<el_ement\nat_tribute=\"\"\n", "el_ement", "at_tribute")]
+    [InlineData("<el:ement\nat:tribute=\"\"\n", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent\nat:tri_bute=\"\"\n", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent\nat-tri_bute=\"\"\n", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent\nat:tri-bute=\"\"\n", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t\nat:tri-but_e=\"\"\n", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1\nattribute0=\"\"\n", "element1", "attribute0")]
+    public void TestElementAndAttributeEmptyValue(string input, string expectedElement, string expectedAttribute)
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Single(element.Attributes);
+        var attribute = element.Attributes[0];
+        Assert.NotEmpty(attribute.Name.ToStringValue());
+        Assert.Equal(expectedAttribute, attribute.Name.ToStringValue());
+        Assert.NotNull(attribute.Value);
+        Assert.Empty(((TextSpan)attribute.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData("<element attribute=\"hogehoge\"", "element", "attribute", "hogehoge")]
+    [InlineData("<el-ement at-tribute=\"hogehoge\"", "el-ement", "at-tribute", "hogehoge")]
+    [InlineData("<el_ement at_tribute=\"hogehoge\"", "el_ement", "at_tribute", "hogehoge")]
+    [InlineData("<el:ement at:tribute=\"hogehoge\"", "el:ement", "at:tribute", "hogehoge")]
+    [InlineData("<el:em_ent at:tri_bute=\"hogehoge\"", "el:em_ent", "at:tri_bute", "hogehoge")]
+    [InlineData("<el-em_ent at-tri_bute=\"hogehoge\"", "el-em_ent", "at-tri_bute", "hogehoge")]
+    [InlineData("<el:em-ent at:tri-bute=\"hogehoge\"", "el:em-ent", "at:tri-bute", "hogehoge")]
+    [InlineData("<el:em-en_t at:tri-but_e=\"hogehoge\"", "el:em-en_t", "at:tri-but_e", "hogehoge")]
+    [InlineData("<element1 attribute0=\"hogehoge\"", "element1", "attribute0", "hogehoge")]
+    [InlineData("<element attribute=\"{hogehoge}\"", "element", "attribute", "{hogehoge}")]
+    [InlineData("<el-ement at-tribute=\"{hogehoge}\"", "el-ement", "at-tribute", "{hogehoge}")]
+    [InlineData("<el_ement at_tribute=\"{hogehoge}\"", "el_ement", "at_tribute", "{hogehoge}")]
+    [InlineData("<el:ement at:tribute=\"{hogehoge}\"", "el:ement", "at:tribute", "{hogehoge}")]
+    [InlineData("<el:em_ent at:tri_bute=\"{hogehoge}\"", "el:em_ent", "at:tri_bute", "{hogehoge}")]
+    [InlineData("<el-em_ent at-tri_bute=\"{hogehoge}\"", "el-em_ent", "at-tri_bute", "{hogehoge}")]
+    [InlineData("<el:em-ent at:tri-bute=\"{hogehoge}\"", "el:em-ent", "at:tri-bute", "{hogehoge}")]
+    [InlineData("<el:em-en_t at:tri-but_e=\"{hogehoge}\"", "el:em-en_t", "at:tri-but_e", "{hogehoge}")]
+    [InlineData("<element1 attribute0=\"{hogehoge}\"", "element1", "attribute0", "{hogehoge}")]
+    public void TestElementAndOneAttribute(string input, string expectedElement, string expectedAttribute, string expectedValue)
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Single(element.Attributes);
+        var attribute = element.Attributes[0];
+        Assert.NotEmpty(attribute.Name.ToStringValue());
+        Assert.Equal(expectedAttribute, attribute.Name.ToStringValue());
+        Assert.NotNull(attribute.Value);
+        Assert.NotEmpty(((TextSpan)attribute.Value!).ToStringValue());
+        Assert.Equal(expectedValue, ((TextSpan)attribute.Value!).ToStringValue());
+    }
+}

--- a/Tests/SAX.TokenParser.Test/ElementAttributeParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/ElementAttributeParserTest.cs
@@ -1,0 +1,92 @@
+using Superpower.Model;
+using XmlFormat.SAX;
+
+namespace SAX.TokenParser.Test;
+
+public class ElementAttributeParserTest
+{
+    [Theory]
+    [InlineData("attribute")]
+    [InlineData("at-tribute")]
+    [InlineData("at_tribute")]
+    [InlineData("at:tribute")]
+    [InlineData("at:tri_bute")]
+    [InlineData("at-tri_bute")]
+    [InlineData("at:tri-bute")]
+    [InlineData("at:tri-but_e")]
+    [InlineData("attribute0")]
+    public void TestElementAttributeNoValue(string input)
+    {
+        var result = XmlTokenParser.ElementAttributeForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attribute = result.Value;
+        Assert.NotEmpty(attribute.Name.ToStringValue());
+        Assert.Equal(input, attribute.Name.ToStringValue());
+        Assert.Null(attribute.Value);
+    }
+
+    [Theory]
+    [InlineData("attribute=\"\"", "attribute")]
+    [InlineData("at-tribute=\"\"", "at-tribute")]
+    [InlineData("at_tribute=\"\"", "at_tribute")]
+    [InlineData("at:tribute=\"\"", "at:tribute")]
+    [InlineData("at:tri_bute=\"\"", "at:tri_bute")]
+    [InlineData("at-tri_bute=\"\"", "at-tri_bute")]
+    [InlineData("at:tri-bute=\"\"", "at:tri-bute")]
+    [InlineData("at:tri-but_e=\"\"", "at:tri-but_e")]
+    [InlineData("attribute0=\"\"", "attribute0")]
+    public void TestElementAttributeEmptyValue(string input, string expected)
+    {
+        var result = XmlTokenParser.ElementAttributeForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attribute = result.Value;
+        Assert.NotEmpty(attribute.Name.ToStringValue());
+        Assert.Equal(expected, attribute.Name.ToStringValue());
+
+        Assert.NotNull(attribute.Value);
+        TextSpan attribValue = (TextSpan)attribute.Value!;
+        Assert.Empty(attribValue.ToStringValue());
+    }
+
+    [Theory]
+    [InlineData("attribute=\"hogehoge\"", "attribute", "hogehoge")]
+    [InlineData("at-tribute=\"hogehoge\"", "at-tribute", "hogehoge")]
+    [InlineData("at_tribute=\"hogehoge\"", "at_tribute", "hogehoge")]
+    [InlineData("at:tribute=\"hogehoge\"", "at:tribute", "hogehoge")]
+    [InlineData("at:tri_bute=\"hogehoge\"", "at:tri_bute", "hogehoge")]
+    [InlineData("at-tri_bute=\"hogehoge\"", "at-tri_bute", "hogehoge")]
+    [InlineData("at:tri-bute=\"hogehoge\"", "at:tri-bute", "hogehoge")]
+    [InlineData("at:tri-but_e=\"hogehoge\"", "at:tri-but_e", "hogehoge")]
+    [InlineData("attribute0=\"hogehoge\"", "attribute0", "hogehoge")]
+    [InlineData("attribute=\"{hogehoge}\"", "attribute", "{hogehoge}")]
+    [InlineData("at-tribute=\"{hogehoge}\"", "at-tribute", "{hogehoge}")]
+    [InlineData("at_tribute=\"{hogehoge}\"", "at_tribute", "{hogehoge}")]
+    [InlineData("at:tribute=\"{hogehoge}\"", "at:tribute", "{hogehoge}")]
+    [InlineData("at:tri_bute=\"{hogehoge}\"", "at:tri_bute", "{hogehoge}")]
+    [InlineData("at-tri_bute=\"{hogehoge}\"", "at-tri_bute", "{hogehoge}")]
+    [InlineData("at:tri-bute=\"{hogehoge}\"", "at:tri-bute", "{hogehoge}")]
+    [InlineData("at:tri-but_e=\"{hogehoge}\"", "at:tri-but_e", "{hogehoge}")]
+    [InlineData("attribute0=\"{hogehoge}\"", "attribute0", "{hogehoge}")]
+    public void TestElementAttribute(string input, string expectedName, string expectedValue)
+    {
+        var result = XmlTokenParser.ElementAttributeForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attribute = result.Value;
+        Assert.NotEmpty(attribute.Name.ToStringValue());
+        Assert.Equal(expectedName, attribute.Name.ToStringValue());
+
+        Assert.NotNull(attribute.Value);
+        TextSpan attribValue = (TextSpan)attribute.Value!;
+        Assert.NotEmpty(attribValue.ToStringValue());
+        Assert.Equal(expectedValue, attribValue.ToStringValue());
+    }
+}

--- a/Tests/SAX.TokenParser.Test/ElementEmptyParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/ElementEmptyParserTest.cs
@@ -1,0 +1,183 @@
+using Superpower.Model;
+using XmlFormat.SAX;
+
+namespace SAX.TokenParser.Test;
+
+public class ElementEmptyParserTest
+{
+    [Theory]
+    [InlineData("<element/>", "element")]
+    [InlineData("<el-ement/>", "el-ement")]
+    [InlineData("<el_ement/>", "el_ement")]
+    [InlineData("<el:ement/>", "el:ement")]
+    [InlineData("<el:em_ent/>", "el:em_ent")]
+    [InlineData("<el-em_ent/>", "el-em_ent")]
+    [InlineData("<el:em-ent/>", "el:em-ent")]
+    [InlineData("<el:em-en_t/>", "el:em-en_t")]
+    [InlineData("<element1/>", "element1")]
+    [InlineData("<element />", "element")]
+    [InlineData("<el-ement />", "el-ement")]
+    [InlineData("<el_ement />", "el_ement")]
+    [InlineData("<el:ement />", "el:ement")]
+    [InlineData("<el:em_ent />", "el:em_ent")]
+    [InlineData("<el-em_ent />", "el-em_ent")]
+    [InlineData("<el:em-ent />", "el:em-ent")]
+    [InlineData("<el:em-en_t />", "el:em-en_t")]
+    [InlineData("<element1 />", "element1")]
+    [InlineData("<element\n />", "element")]
+    [InlineData("<el-ement\n />", "el-ement")]
+    [InlineData("<el_ement\n />", "el_ement")]
+    [InlineData("<el:ement\n />", "el:ement")]
+    [InlineData("<el:em_ent\n />", "el:em_ent")]
+    [InlineData("<el-em_ent\n />", "el-em_ent")]
+    [InlineData("<el:em-ent\n />", "el:em-ent")]
+    [InlineData("<el:em-en_t\n />", "el:em-en_t")]
+    [InlineData("<element1\n />", "element1")]
+    public void TestElementEmptyNoAttributes(string input, string expected)
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expected, element.Identifier.ToStringValue());
+        Assert.Empty(element.Attributes);
+    }
+
+    [Theory]
+    [InlineData("<element attribute/>", "element", "attribute")]
+    [InlineData("<el-ement at-tribute/>", "el-ement", "at-tribute")]
+    [InlineData("<el_ement at_tribute/>", "el_ement", "at_tribute")]
+    [InlineData("<el:ement at:tribute/>", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent at:tri_bute/>", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent at-tri_bute/>", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent at:tri-bute/>", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t at:tri-but_e/>", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1 attribute0/>", "element1", "attribute0")]
+    [InlineData("<element attribute />", "element", "attribute")]
+    [InlineData("<el-ement at-tribute />", "el-ement", "at-tribute")]
+    [InlineData("<el_ement at_tribute />", "el_ement", "at_tribute")]
+    [InlineData("<el:ement at:tribute />", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent at:tri_bute />", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent at-tri_bute />", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent at:tri-bute />", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t at:tri-but_e />", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1 attribute0 />", "element1", "attribute0")]
+    [InlineData("<element\nattribute \n/>", "element", "attribute")]
+    [InlineData("<el-ement\nat-tribute \n/>", "el-ement", "at-tribute")]
+    [InlineData("<el_ement\nat_tribute \n/>", "el_ement", "at_tribute")]
+    [InlineData("<el:ement\nat:tribute \n/>", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent\nat:tri_bute \n/>", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent\nat-tri_bute \n/>", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent\nat:tri-bute \n/>", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t\nat:tri-but_e \n/>", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1\nattribute0 \n/>", "element1", "attribute0")]
+    public void TestElementEmptyWithAttributeNoValue(string input, string expectedElement, string expectedAttribute)
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Single(element.Attributes);
+        var attribute = element.Attributes[0];
+        Assert.NotEmpty(attribute.Name.ToStringValue());
+        Assert.Equal(expectedAttribute, attribute.Name.ToStringValue());
+        Assert.Null(attribute.Value);
+    }
+
+    [Theory]
+    [InlineData("<element attribute=\"\"/>", "element", "attribute")]
+    [InlineData("<el-ement at-tribute=\"\"/>", "el-ement", "at-tribute")]
+    [InlineData("<el_ement at_tribute=\"\"/>", "el_ement", "at_tribute")]
+    [InlineData("<el:ement at:tribute=\"\"/>", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent at:tri_bute=\"\"/>", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent at-tri_bute=\"\"/>", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent at:tri-bute=\"\"/>", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t at:tri-but_e=\"\"/>", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1 attribute0=\"\"/>", "element1", "attribute0")]
+    [InlineData("<element attribute=\"\" />", "element", "attribute")]
+    [InlineData("<el-ement at-tribute=\"\" />", "el-ement", "at-tribute")]
+    [InlineData("<el_ement at_tribute=\"\" />", "el_ement", "at_tribute")]
+    [InlineData("<el:ement at:tribute=\"\" />", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent at:tri_bute=\"\" />", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent at-tri_bute=\"\" />", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent at:tri-bute=\"\" />", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t at:tri-but_e=\"\" />", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1 attribute0=\"\" />", "element1", "attribute0")]
+    [InlineData("<element\nattribute=\"\"\n/>", "element", "attribute")]
+    [InlineData("<el-ement\nat-tribute=\"\"\n/>", "el-ement", "at-tribute")]
+    [InlineData("<el_ement\nat_tribute=\"\"\n/>", "el_ement", "at_tribute")]
+    [InlineData("<el:ement\nat:tribute=\"\"\n/>", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent\nat:tri_bute=\"\"\n/>", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent\nat-tri_bute=\"\"\n/>", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent\nat:tri-bute=\"\"\n/>", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t\nat:tri-but_e=\"\"\n/>", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1\nattribute0=\"\"\n/>", "element1", "attribute0")]
+    public void TestElementAttributeEmptyValue(string input, string expectedElement, string expectedAttribute)
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Single(element.Attributes);
+        var attribute = element.Attributes[0];
+        Assert.NotEmpty(attribute.Name.ToStringValue());
+        Assert.Equal(expectedAttribute, attribute.Name.ToStringValue());
+        Assert.NotNull(attribute.Value);
+        Assert.Empty(((TextSpan)attribute.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData("<element attribute=\"hogehoge\"/>", "element", "attribute", "hogehoge")]
+    [InlineData("<el-ement at-tribute=\"hogehoge\"/>", "el-ement", "at-tribute", "hogehoge")]
+    [InlineData("<el_ement at_tribute=\"hogehoge\"/>", "el_ement", "at_tribute", "hogehoge")]
+    [InlineData("<el:ement at:tribute=\"hogehoge\"/>", "el:ement", "at:tribute", "hogehoge")]
+    [InlineData("<el:em_ent at:tri_bute=\"hogehoge\"/>", "el:em_ent", "at:tri_bute", "hogehoge")]
+    [InlineData("<el-em_ent at-tri_bute=\"hogehoge\"/>", "el-em_ent", "at-tri_bute", "hogehoge")]
+    [InlineData("<el:em-ent at:tri-bute=\"hogehoge\"/>", "el:em-ent", "at:tri-bute", "hogehoge")]
+    [InlineData("<el:em-en_t at:tri-but_e=\"hogehoge\"/>", "el:em-en_t", "at:tri-but_e", "hogehoge")]
+    [InlineData("<element1 attribute0=\"hogehoge\"/>", "element1", "attribute0", "hogehoge")]
+    [InlineData("<element attribute=\"{hogehoge}\"/>", "element", "attribute", "{hogehoge}")]
+    [InlineData("<el-ement at-tribute=\"{hogehoge}\"/>", "el-ement", "at-tribute", "{hogehoge}")]
+    [InlineData("<el_ement at_tribute=\"{hogehoge}\"/>", "el_ement", "at_tribute", "{hogehoge}")]
+    [InlineData("<el:ement at:tribute=\"{hogehoge}\"/>", "el:ement", "at:tribute", "{hogehoge}")]
+    [InlineData("<el:em_ent at:tri_bute=\"{hogehoge}\"/>", "el:em_ent", "at:tri_bute", "{hogehoge}")]
+    [InlineData("<el-em_ent at-tri_bute=\"{hogehoge}\"/>", "el-em_ent", "at-tri_bute", "{hogehoge}")]
+    [InlineData("<el:em-ent at:tri-bute=\"{hogehoge}\"/>", "el:em-ent", "at:tri-bute", "{hogehoge}")]
+    [InlineData("<el:em-en_t at:tri-but_e=\"{hogehoge}\"/>", "el:em-en_t", "at:tri-but_e", "{hogehoge}")]
+    [InlineData("<element1 attribute0=\"{hogehoge}\"/>", "element1", "attribute0", "{hogehoge}")]
+    public void TestElementAttribute(string input, string expectedElement, string expectedAttribute, string expectedValue)
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Single(element.Attributes);
+        var attribute = element.Attributes[0];
+        Assert.NotEmpty(attribute.Name.ToStringValue());
+        Assert.Equal(expectedAttribute, attribute.Name.ToStringValue());
+        Assert.NotNull(attribute.Value);
+        Assert.NotEmpty(((TextSpan)attribute.Value!).ToStringValue());
+        Assert.Equal(expectedValue, ((TextSpan)attribute.Value!).ToStringValue());
+    }
+}

--- a/Tests/SAX.TokenParser.Test/ElementEndParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/ElementEndParserTest.cs
@@ -1,0 +1,47 @@
+using Superpower.Model;
+using XmlFormat.SAX;
+
+namespace SAX.TokenParser.Test;
+
+public class ElementEndParserTest
+{
+    [Theory]
+    [InlineData("</element>", "element")]
+    [InlineData("</el-ement>", "el-ement")]
+    [InlineData("</el_ement>", "el_ement")]
+    [InlineData("</el:ement>", "el:ement")]
+    [InlineData("</el:em_ent>", "el:em_ent")]
+    [InlineData("</el-em_ent>", "el-em_ent")]
+    [InlineData("</el:em-ent>", "el:em-ent")]
+    [InlineData("</el:em-en_t>", "el:em-en_t")]
+    [InlineData("</element1>", "element1")]
+    [InlineData("</element >", "element")]
+    [InlineData("</el-ement >", "el-ement")]
+    [InlineData("</el_ement >", "el_ement")]
+    [InlineData("</el:ement >", "el:ement")]
+    [InlineData("</el:em_ent >", "el:em_ent")]
+    [InlineData("</el-em_ent >", "el-em_ent")]
+    [InlineData("</el:em-ent >", "el:em-ent")]
+    [InlineData("</el:em-en_t >", "el:em-en_t")]
+    [InlineData("</element1 >", "element1")]
+    [InlineData("</element\n >", "element")]
+    [InlineData("</el-ement\n >", "el-ement")]
+    [InlineData("</el_ement\n >", "el_ement")]
+    [InlineData("</el:ement\n >", "el:ement")]
+    [InlineData("</el:em_ent\n >", "el:em_ent")]
+    [InlineData("</el-em_ent\n >", "el-em_ent")]
+    [InlineData("</el:em-ent\n >", "el:em-ent")]
+    [InlineData("</el:em-en_t\n >", "el:em-en_t")]
+    [InlineData("</element1\n >", "element1")]
+    public void TestElementEnd(string input, string expected)
+    {
+        var result = XmlTokenParser.ElementEnd(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.ToStringValue());
+        Assert.Equal(expected, element.ToStringValue());
+    }
+}

--- a/Tests/SAX.TokenParser.Test/ElementIdentifierParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/ElementIdentifierParserTest.cs
@@ -1,0 +1,29 @@
+using Superpower.Model;
+using XmlFormat.SAX;
+
+namespace SAX.TokenParser.Test;
+
+public class ElementIdentifierParserTest
+{
+    [Theory]
+    [InlineData("<element", "element")]
+    [InlineData("<el-ement", "el-ement")]
+    [InlineData("<el_ement", "el_ement")]
+    [InlineData("<el:ement", "el:ement")]
+    [InlineData("<el:em_ent", "el:em_ent")]
+    [InlineData("<el-em_ent", "el-em_ent")]
+    [InlineData("<el:em-ent", "el:em-ent")]
+    [InlineData("<el:em-en_t", "el:em-en_t")]
+    [InlineData("<element1", "element1")]
+    public void TestElementIdentifier(string input, string expected)
+    {
+        var result = XmlTokenParser.ElementIdentifierForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var chars = result.Value;
+        Assert.NotEmpty(chars.ToStringValue());
+        Assert.True(chars.EqualsValue(expected));
+    }
+}

--- a/Tests/SAX.TokenParser.Test/ElementStartParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/ElementStartParserTest.cs
@@ -1,0 +1,183 @@
+using Superpower.Model;
+using XmlFormat.SAX;
+
+namespace SAX.TokenParser.Test;
+
+public class ElementStartParserTest
+{
+    [Theory]
+    [InlineData("<element>", "element")]
+    [InlineData("<el-ement>", "el-ement")]
+    [InlineData("<el_ement>", "el_ement")]
+    [InlineData("<el:ement>", "el:ement")]
+    [InlineData("<el:em_ent>", "el:em_ent")]
+    [InlineData("<el-em_ent>", "el-em_ent")]
+    [InlineData("<el:em-ent>", "el:em-ent")]
+    [InlineData("<el:em-en_t>", "el:em-en_t")]
+    [InlineData("<element1>", "element1")]
+    [InlineData("<element >", "element")]
+    [InlineData("<el-ement >", "el-ement")]
+    [InlineData("<el_ement >", "el_ement")]
+    [InlineData("<el:ement >", "el:ement")]
+    [InlineData("<el:em_ent >", "el:em_ent")]
+    [InlineData("<el-em_ent >", "el-em_ent")]
+    [InlineData("<el:em-ent >", "el:em-ent")]
+    [InlineData("<el:em-en_t >", "el:em-en_t")]
+    [InlineData("<element1 >", "element1")]
+    [InlineData("<element\n >", "element")]
+    [InlineData("<el-ement\n >", "el-ement")]
+    [InlineData("<el_ement\n >", "el_ement")]
+    [InlineData("<el:ement\n >", "el:ement")]
+    [InlineData("<el:em_ent\n >", "el:em_ent")]
+    [InlineData("<el-em_ent\n >", "el-em_ent")]
+    [InlineData("<el:em-ent\n >", "el:em-ent")]
+    [InlineData("<el:em-en_t\n >", "el:em-en_t")]
+    [InlineData("<element1\n >", "element1")]
+    public void TestElementStartNoAttributes(string input, string expected)
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expected, element.Identifier.ToStringValue());
+        Assert.Empty(element.Attributes);
+    }
+
+    [Theory]
+    [InlineData("<element attribute>", "element", "attribute")]
+    [InlineData("<el-ement at-tribute>", "el-ement", "at-tribute")]
+    [InlineData("<el_ement at_tribute>", "el_ement", "at_tribute")]
+    [InlineData("<el:ement at:tribute>", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent at:tri_bute>", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent at-tri_bute>", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent at:tri-bute>", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t at:tri-but_e>", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1 attribute0>", "element1", "attribute0")]
+    [InlineData("<element attribute >", "element", "attribute")]
+    [InlineData("<el-ement at-tribute >", "el-ement", "at-tribute")]
+    [InlineData("<el_ement at_tribute >", "el_ement", "at_tribute")]
+    [InlineData("<el:ement at:tribute >", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent at:tri_bute >", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent at-tri_bute >", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent at:tri-bute >", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t at:tri-but_e >", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1 attribute0 >", "element1", "attribute0")]
+    [InlineData("<element\nattribute \n>", "element", "attribute")]
+    [InlineData("<el-ement\nat-tribute \n>", "el-ement", "at-tribute")]
+    [InlineData("<el_ement\nat_tribute \n>", "el_ement", "at_tribute")]
+    [InlineData("<el:ement\nat:tribute \n>", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent\nat:tri_bute \n>", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent\nat-tri_bute \n>", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent\nat:tri-bute \n>", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t\nat:tri-but_e \n>", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1\nattribute0 \n>", "element1", "attribute0")]
+    public void TestElementStartWithAttributeNoValue(string input, string expectedElement, string expectedAttribute)
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Single(element.Attributes);
+        var attribute = element.Attributes[0];
+        Assert.NotEmpty(attribute.Name.ToStringValue());
+        Assert.Equal(expectedAttribute, attribute.Name.ToStringValue());
+        Assert.Null(attribute.Value);
+    }
+
+    [Theory]
+    [InlineData("<element attribute=\"\">", "element", "attribute")]
+    [InlineData("<el-ement at-tribute=\"\">", "el-ement", "at-tribute")]
+    [InlineData("<el_ement at_tribute=\"\">", "el_ement", "at_tribute")]
+    [InlineData("<el:ement at:tribute=\"\">", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent at:tri_bute=\"\">", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent at-tri_bute=\"\">", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent at:tri-bute=\"\">", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t at:tri-but_e=\"\">", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1 attribute0=\"\">", "element1", "attribute0")]
+    [InlineData("<element attribute=\"\" >", "element", "attribute")]
+    [InlineData("<el-ement at-tribute=\"\" >", "el-ement", "at-tribute")]
+    [InlineData("<el_ement at_tribute=\"\" >", "el_ement", "at_tribute")]
+    [InlineData("<el:ement at:tribute=\"\" >", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent at:tri_bute=\"\" >", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent at-tri_bute=\"\" >", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent at:tri-bute=\"\" >", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t at:tri-but_e=\"\" >", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1 attribute0=\"\" >", "element1", "attribute0")]
+    [InlineData("<element\nattribute=\"\"\n>", "element", "attribute")]
+    [InlineData("<el-ement\nat-tribute=\"\"\n>", "el-ement", "at-tribute")]
+    [InlineData("<el_ement\nat_tribute=\"\"\n>", "el_ement", "at_tribute")]
+    [InlineData("<el:ement\nat:tribute=\"\"\n>", "el:ement", "at:tribute")]
+    [InlineData("<el:em_ent\nat:tri_bute=\"\"\n>", "el:em_ent", "at:tri_bute")]
+    [InlineData("<el-em_ent\nat-tri_bute=\"\"\n>", "el-em_ent", "at-tri_bute")]
+    [InlineData("<el:em-ent\nat:tri-bute=\"\"\n>", "el:em-ent", "at:tri-bute")]
+    [InlineData("<el:em-en_t\nat:tri-but_e=\"\"\n>", "el:em-en_t", "at:tri-but_e")]
+    [InlineData("<element1\nattribute0=\"\"\n>", "element1", "attribute0")]
+    public void TestElementAttributeEmptyValue(string input, string expectedElement, string expectedAttribute)
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Single(element.Attributes);
+        var attribute = element.Attributes[0];
+        Assert.NotEmpty(attribute.Name.ToStringValue());
+        Assert.Equal(expectedAttribute, attribute.Name.ToStringValue());
+        Assert.NotNull(attribute.Value);
+        Assert.Empty(((TextSpan)attribute.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData("<element attribute=\"hogehoge\">", "element", "attribute", "hogehoge")]
+    [InlineData("<el-ement at-tribute=\"hogehoge\">", "el-ement", "at-tribute", "hogehoge")]
+    [InlineData("<el_ement at_tribute=\"hogehoge\">", "el_ement", "at_tribute", "hogehoge")]
+    [InlineData("<el:ement at:tribute=\"hogehoge\">", "el:ement", "at:tribute", "hogehoge")]
+    [InlineData("<el:em_ent at:tri_bute=\"hogehoge\">", "el:em_ent", "at:tri_bute", "hogehoge")]
+    [InlineData("<el-em_ent at-tri_bute=\"hogehoge\">", "el-em_ent", "at-tri_bute", "hogehoge")]
+    [InlineData("<el:em-ent at:tri-bute=\"hogehoge\">", "el:em-ent", "at:tri-bute", "hogehoge")]
+    [InlineData("<el:em-en_t at:tri-but_e=\"hogehoge\">", "el:em-en_t", "at:tri-but_e", "hogehoge")]
+    [InlineData("<element1 attribute0=\"hogehoge\">", "element1", "attribute0", "hogehoge")]
+    [InlineData("<element attribute=\"{hogehoge}\">", "element", "attribute", "{hogehoge}")]
+    [InlineData("<el-ement at-tribute=\"{hogehoge}\">", "el-ement", "at-tribute", "{hogehoge}")]
+    [InlineData("<el_ement at_tribute=\"{hogehoge}\">", "el_ement", "at_tribute", "{hogehoge}")]
+    [InlineData("<el:ement at:tribute=\"{hogehoge}\">", "el:ement", "at:tribute", "{hogehoge}")]
+    [InlineData("<el:em_ent at:tri_bute=\"{hogehoge}\">", "el:em_ent", "at:tri_bute", "{hogehoge}")]
+    [InlineData("<el-em_ent at-tri_bute=\"{hogehoge}\">", "el-em_ent", "at-tri_bute", "{hogehoge}")]
+    [InlineData("<el:em-ent at:tri-bute=\"{hogehoge}\">", "el:em-ent", "at:tri-bute", "{hogehoge}")]
+    [InlineData("<el:em-en_t at:tri-but_e=\"{hogehoge}\">", "el:em-en_t", "at:tri-but_e", "{hogehoge}")]
+    [InlineData("<element1 attribute0=\"{hogehoge}\">", "element1", "attribute0", "{hogehoge}")]
+    public void TestElementAttribute(string input, string expectedElement, string expectedAttribute, string expectedValue)
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Single(element.Attributes);
+        var attribute = element.Attributes[0];
+        Assert.NotEmpty(attribute.Name.ToStringValue());
+        Assert.Equal(expectedAttribute, attribute.Name.ToStringValue());
+        Assert.NotNull(attribute.Value);
+        Assert.NotEmpty(((TextSpan)attribute.Value!).ToStringValue());
+        Assert.Equal(expectedValue, ((TextSpan)attribute.Value!).ToStringValue());
+    }
+}

--- a/Tests/SAX.TokenParser.Test/QuotedStringParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/QuotedStringParserTest.cs
@@ -1,0 +1,62 @@
+using Superpower.Model;
+using XmlFormat.SAX;
+
+namespace SAX.TokenParser.Test;
+
+public class QuotedStringParserTest
+{
+    [Theory]
+    [InlineData("\"\"")]
+    [InlineData("\"1234\"")]
+    [InlineData("\"hogehoge\"")]
+    [InlineData("\"{hogehoge}\"")]
+    [InlineData("\"{hogehoge;}\"")]
+    [InlineData("\"Supercalifragilisticexpialidocious\"")]
+    [InlineData("\"Supercalifragilisticexpialidocious.\"")]
+    [InlineData("\"The quick brown fox jumped over the lazy dog.\"")]
+    public void TestQuotedStringWithQuotes(string input)
+    {
+        var result = XmlTokenParser.QuotedStringWithQuotes(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var chars = result.Value;
+        Assert.NotEmpty(chars.ToStringValue());
+        Assert.True(chars.EqualsValue(input));
+    }
+
+    [Theory]
+    [InlineData("\"\"")]
+    public void TestEmptyQuotedString(string input)
+    {
+        var result = XmlTokenParser.QuotedString(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var chars = result.Value;
+        Assert.Empty(chars.ToStringValue());
+        Assert.Equal(input.Trim('"'), chars.ToStringValue());
+    }
+
+    [Theory]
+    [InlineData("\"1234\"")]
+    [InlineData("\"hogehoge\"")]
+    [InlineData("\"{hogehoge}\"")]
+    [InlineData("\"{hogehoge;}\"")]
+    [InlineData("\"Supercalifragilisticexpialidocious\"")]
+    [InlineData("\"Supercalifragilisticexpialidocious.\"")]
+    [InlineData("\"The quick brown fox jumped over the lazy dog.\"")]
+    public void TestQuotedString(string input)
+    {
+        var result = XmlTokenParser.QuotedString(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var chars = result.Value;
+        Assert.NotEmpty(chars.ToStringValue());
+        Assert.Equal(input.Trim('"'), chars.ToStringValue());
+    }
+}

--- a/Tests/SAX.TokenParser.Test/SAX.TokenParser.Test.csproj
+++ b/Tests/SAX.TokenParser.Test/SAX.TokenParser.Test.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>SAX.TokenParser.Test</RootNamespace>
+    <TargetFramework>net9.0</TargetFramework>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <!--
+    To enable the Microsoft Testing Platform 'dotnet test' experience, add property:
+      <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+
+    To enable the Microsoft Testing Platform native command line experience, add property:
+      <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+
+    For more information on Microsoft Testing Platform support in xUnit.net, please visit:
+      https://xunit.net/docs/getting-started/v3/microsoft-testing-platform
+    -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup Label="package dependencies">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup Label="project dependencies">
+    <ProjectReference Include="..\..\XmlFormat.SAX\XmlFormat.SAX.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/SAX.TokenParser.Test/XmlCharsParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/XmlCharsParserTest.cs
@@ -1,0 +1,138 @@
+using Superpower.Model;
+using XmlFormat.SAX;
+
+namespace SAX.TokenParser.Test;
+
+public class XmlCharsParserTest
+{
+    [Theory]
+    [InlineData("a")]
+    [InlineData("b")]
+    [InlineData("c")]
+    [InlineData("d")]
+    [InlineData("e")]
+    [InlineData("f")]
+    [InlineData("g")]
+    [InlineData("h")]
+    [InlineData("i")]
+    [InlineData("j")]
+    [InlineData("k")]
+    [InlineData("l")]
+    [InlineData("m")]
+    [InlineData("n")]
+    [InlineData("o")]
+    [InlineData("p")]
+    [InlineData("q")]
+    [InlineData("r")]
+    [InlineData("s")]
+    [InlineData("t")]
+    [InlineData("u")]
+    [InlineData("v")]
+    [InlineData("w")]
+    [InlineData("x")]
+    [InlineData("y")]
+    [InlineData("z")]
+    [InlineData("A")]
+    [InlineData("B")]
+    [InlineData("C")]
+    [InlineData("D")]
+    [InlineData("E")]
+    [InlineData("F")]
+    [InlineData("G")]
+    [InlineData("H")]
+    [InlineData("I")]
+    [InlineData("J")]
+    [InlineData("K")]
+    [InlineData("L")]
+    [InlineData("M")]
+    [InlineData("N")]
+    [InlineData("O")]
+    [InlineData("P")]
+    [InlineData("Q")]
+    [InlineData("R")]
+    [InlineData("S")]
+    [InlineData("T")]
+    [InlineData("U")]
+    [InlineData("V")]
+    [InlineData("W")]
+    [InlineData("X")]
+    [InlineData("Y")]
+    [InlineData("Z")]
+    [InlineData("0")]
+    [InlineData("1")]
+    [InlineData("2")]
+    [InlineData("3")]
+    [InlineData("4")]
+    [InlineData("5")]
+    [InlineData("6")]
+    [InlineData("7")]
+    [InlineData("8")]
+    [InlineData("9")]
+    [InlineData(":")]
+    [InlineData("-")]
+    [InlineData("_")]
+    [InlineData("attribute")]
+    [InlineData("element")]
+    [InlineData("at-tribute")]
+    [InlineData("el-ement")]
+    [InlineData("at_tribute")]
+    [InlineData("el_ement")]
+    [InlineData("at:tribute")]
+    [InlineData("el:ement")]
+    [InlineData("at:tri_bute")]
+    [InlineData("el:em_ent")]
+    [InlineData("at-tri_bute")]
+    [InlineData("el-em_ent")]
+    [InlineData("at:tri-bute")]
+    [InlineData("el:em-ent")]
+    [InlineData("at:tri-but_e")]
+    [InlineData("el:em-en_t")]
+    [InlineData("attribute0")]
+    [InlineData("element1")]
+    public void TestXmlChars(string input)
+    {
+        var result = XmlTokenParser.XmlChars(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var chars = result.Value;
+        Assert.NotEmpty(chars.ToStringValue());
+        Assert.True(chars.EqualsValue(input));
+    }
+
+    [Theory]
+    [InlineData("<")]
+    [InlineData(">")]
+    [InlineData("(")]
+    [InlineData(")")]
+    [InlineData("[")]
+    [InlineData("]")]
+    [InlineData("{")]
+    [InlineData("}")]
+    [InlineData(";")]
+    [InlineData("?")]
+    [InlineData(",")]
+    [InlineData(".")]
+    [InlineData("!")]
+    [InlineData("+")]
+    [InlineData("=")]
+    [InlineData("@")]
+    [InlineData("$")]
+    [InlineData("%")]
+    [InlineData("^")]
+    [InlineData("&")]
+    [InlineData("*")]
+    [InlineData("'")]
+    [InlineData("|")]
+    [InlineData("\\")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    [InlineData("\n")]
+    void DisallowedCharacters(string input)
+    {
+        var result = XmlTokenParser.XmlChars(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+        Assert.False(result.HasValue);
+    }
+}

--- a/Tests/SAX.TokenParser.Test/xunit.runner.json
+++ b/Tests/SAX.TokenParser.Test/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}

--- a/XmlFormat.SAX/TextSpanExtensions.cs
+++ b/XmlFormat.SAX/TextSpanExtensions.cs
@@ -1,0 +1,15 @@
+using Superpower.Model;
+
+namespace XmlFormat.SAX;
+
+public static class TextSpanExtensions
+{
+    public static TextSpan Trim(this TextSpan span, string chars) => span.Trim(chars, chars);
+
+    public static TextSpan Trim(this TextSpan span, string left, string right) =>
+        new(
+            span.Source!,
+            new Position(span.Position.Absolute + left.Length, span.Position.Line, span.Position.Column + left.Length),
+            span.Length - left.Length - right.Length
+        );
+}

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -61,4 +61,9 @@ public static class XmlTokenParser
     }
 
     public record struct Attribute(TextSpan Name, TextSpan? Value = default);
+
+    internal static TextParser<Attribute> ElementAttribute { get; } =
+        from identifier in XmlChars
+        from value in Span.EqualTo("=").IgnoreThen(QuotedString).Optional()
+        select new Attribute(identifier, value);
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -54,4 +54,9 @@ public static class XmlTokenParser
     internal static TextParser<TextSpan> ElementIdentifier { get; } =
         from identifier in Character.EqualTo('<').IgnoreThen(XmlChars)
         select identifier;
+
+    public static TextParser<TextSpan> ElementIdentifierForUnitTestsOnly
+    {
+        get => ElementIdentifier;
+    }
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -28,6 +28,8 @@ public static class XmlTokenParser
             return Result.Value(trimmed, input, remainder);
         };
 
+    public static TextParser<TextSpan> TrimCData { get; } = Trim("<![CDATA[", "]]>");
+
     public static TextParser<char> XmlChar { get; } =
         Character.LetterOrDigit.Or(Character.EqualTo(':')).Or(Character.EqualTo('_')).Or(Character.EqualTo('-'));
 

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -13,4 +13,7 @@ public static class XmlTokenParser
 {
     public static TextParser<char> XmlChar { get; } =
         Character.LetterOrDigit.Or(Character.EqualTo(':')).Or(Character.EqualTo('_')).Or(Character.EqualTo('-'));
+
+    public static TextParser<TextSpan> XmlChars { get; } =
+        Span.WithAll(ch => !Char.IsWhiteSpace(ch) && (Char.IsLetterOrDigit(ch) || ch == '_' || ch == '-' || ch == ':'));
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Superpower;
+using Superpower.Display;
+using Superpower.Model;
+using Superpower.Parsers;
+using Superpower.Tokenizers;
+
+namespace XmlFormat.SAX;
+
+public static class XmlTokenParser
+{
+    public static TextParser<char> XmlChar { get; } =
+        Character.LetterOrDigit.Or(Character.EqualTo(':')).Or(Character.EqualTo('_')).Or(Character.EqualTo('-'));
+}

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -80,4 +80,10 @@ public static class XmlTokenParser
         from identifier in ElementIdentifier
         from attributes in Character.WhiteSpace.Many().IgnoreThen(ElementAttribute.Many())
         select new Element(identifier, attributes);
+
+    public static TextParser<Element> ElementStart { get; } =
+        from identifier in ElementIdentifier
+        from attributes in Character.WhiteSpace.Many().IgnoreThen(ElementAttribute.Many())
+        from closing in Character.WhiteSpace.Many().IgnoreThen(Character.EqualTo('>'))
+        select new Element(identifier, attributes);
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -92,4 +92,9 @@ public static class XmlTokenParser
         from attributes in Character.WhiteSpace.Many().IgnoreThen(ElementAttribute.Many())
         from closing in Character.WhiteSpace.Many().IgnoreThen(Span.EqualTo("/>"))
         select new Element(identifier, attributes);
+
+    public static TextParser<TextSpan> ElementEnd { get; } =
+        from identifier in Span.EqualTo("</").IgnoreThen(XmlChars)
+        from closing in Character.WhiteSpace.Many().IgnoreThen(Character.EqualTo('>'))
+        select identifier;
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -75,4 +75,9 @@ public static class XmlTokenParser
     public static TextParser<Attribute[]> ManyElementAttributesForUnitTestsOnly { get; } = ElementAttribute.Many();
 
     public record struct Element(TextSpan Identifier, Attribute[] Attributes);
+
+    public static TextParser<Element> ElementAndAttributesForUnitTestsOnly { get; } =
+        from identifier in ElementIdentifier
+        from attributes in Character.WhiteSpace.Many().IgnoreThen(ElementAttribute.Many())
+        select new Element(identifier, attributes);
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -36,4 +36,14 @@ public static class XmlTokenParser
 
     public static TextParser<TextSpan> XmlChars { get; } =
         Span.WithAll(ch => !Char.IsWhiteSpace(ch) && (Char.IsLetterOrDigit(ch) || ch == '_' || ch == '-' || ch == ':'));
+
+    public static TextParser<TextSpan> QuotedStringWithQuotes { get; } =
+        from lq in Span.EqualTo("\"")
+        from qt in Span.Except("\"").Optional()
+        from rq in Span.EqualTo("\"")
+        select new TextSpan(
+            lq.Source!,
+            new Position(lq.Position.Absolute, lq.Position.Line, lq.Position.Column),
+            2 + (qt?.Length ?? 0) //rq.Position.Absolute - lq.Position.Absolute + 1
+        );
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -86,4 +86,10 @@ public static class XmlTokenParser
         from attributes in Character.WhiteSpace.Many().IgnoreThen(ElementAttribute.Many())
         from closing in Character.WhiteSpace.Many().IgnoreThen(Character.EqualTo('>'))
         select new Element(identifier, attributes);
+
+    public static TextParser<Element> ElementEmpty { get; } =
+        from identifier in ElementIdentifier
+        from attributes in Character.WhiteSpace.Many().IgnoreThen(ElementAttribute.Many())
+        from closing in Character.WhiteSpace.Many().IgnoreThen(Span.EqualTo("/>"))
+        select new Element(identifier, attributes);
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -71,4 +71,6 @@ public static class XmlTokenParser
     {
         get => ElementAttribute;
     }
+
+    public static TextParser<Attribute[]> ManyElementAttributesForUnitTestsOnly { get; } = ElementAttribute.Many();
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -11,6 +11,23 @@ namespace XmlFormat.SAX;
 
 public static class XmlTokenParser
 {
+    public static TextParser<TextSpan> Trim(string left, string right) =>
+        (TextSpan input) =>
+        {
+            TextSpan trimmed = input.Trim(left, right);
+            TextSpan remainder =
+                new(
+                    trimmed.Source!,
+                    new Position(
+                        trimmed.Position.Absolute + trimmed.Length + right.Length,
+                        trimmed.Position.Line,
+                        trimmed.Position.Column + trimmed.Length + right.Length
+                    ),
+                    0
+                );
+            return Result.Value(trimmed, input, remainder);
+        };
+
     public static TextParser<char> XmlChar { get; } =
         Character.LetterOrDigit.Or(Character.EqualTo(':')).Or(Character.EqualTo('_')).Or(Character.EqualTo('-'));
 

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -59,4 +59,6 @@ public static class XmlTokenParser
     {
         get => ElementIdentifier;
     }
+
+    public record struct Attribute(TextSpan Name, TextSpan? Value = default);
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -66,4 +66,9 @@ public static class XmlTokenParser
         from identifier in XmlChars
         from value in Span.EqualTo("=").IgnoreThen(QuotedString).Optional()
         select new Attribute(identifier, value);
+
+    public static TextParser<Attribute> ElementAttributeForUnitTestsOnly
+    {
+        get => ElementAttribute;
+    }
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -46,4 +46,8 @@ public static class XmlTokenParser
             new Position(lq.Position.Absolute, lq.Position.Line, lq.Position.Column),
             2 + (qt?.Length ?? 0) //rq.Position.Absolute - lq.Position.Absolute + 1
         );
+
+    public static TextParser<TextSpan> QuotedString { get; } =
+        from qs in QuotedStringWithQuotes
+        select qs.Trim("\"", "\"");
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -29,6 +29,7 @@ public static class XmlTokenParser
         };
 
     public static TextParser<TextSpan> TrimCData { get; } = Trim("<![CDATA[", "]]>");
+    public static TextParser<TextSpan> TrimComment { get; } = Trim("<!--", "-->");
 
     public static TextParser<char> XmlChar { get; } =
         Character.LetterOrDigit.Or(Character.EqualTo(':')).Or(Character.EqualTo('_')).Or(Character.EqualTo('-'));

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -50,4 +50,8 @@ public static class XmlTokenParser
     public static TextParser<TextSpan> QuotedString { get; } =
         from qs in QuotedStringWithQuotes
         select qs.Trim("\"", "\"");
+
+    internal static TextParser<TextSpan> ElementIdentifier { get; } =
+        from identifier in Character.EqualTo('<').IgnoreThen(XmlChars)
+        select identifier;
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -73,4 +73,6 @@ public static class XmlTokenParser
     }
 
     public static TextParser<Attribute[]> ManyElementAttributesForUnitTestsOnly { get; } = ElementAttribute.Many();
+
+    public record struct Element(TextSpan Identifier, Attribute[] Attributes);
 }

--- a/XmlFormat.sln
+++ b/XmlFormat.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{E323078B
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SAX.Tokenizer.Test", "Tests\SAX.Tokenizer.Test\SAX.Tokenizer.Test.csproj", "{DBC4A0DA-8CC2-4957-BEA8-FC6779DAB486}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SAX.TokenParser.Test", "Tests\SAX.TokenParser.Test\SAX.TokenParser.Test.csproj", "{465AA074-CAA7-427C-9931-5F81A2548340}"
+EndProject
 Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -74,8 +76,21 @@ Global
 		{DBC4A0DA-8CC2-4957-BEA8-FC6779DAB486}.Release|x64.Build.0 = Release|Any CPU
 		{DBC4A0DA-8CC2-4957-BEA8-FC6779DAB486}.Release|x86.ActiveCfg = Release|Any CPU
 		{DBC4A0DA-8CC2-4957-BEA8-FC6779DAB486}.Release|x86.Build.0 = Release|Any CPU
+		{465AA074-CAA7-427C-9931-5F81A2548340}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{465AA074-CAA7-427C-9931-5F81A2548340}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{465AA074-CAA7-427C-9931-5F81A2548340}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{465AA074-CAA7-427C-9931-5F81A2548340}.Debug|x64.Build.0 = Debug|Any CPU
+		{465AA074-CAA7-427C-9931-5F81A2548340}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{465AA074-CAA7-427C-9931-5F81A2548340}.Debug|x86.Build.0 = Debug|Any CPU
+		{465AA074-CAA7-427C-9931-5F81A2548340}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{465AA074-CAA7-427C-9931-5F81A2548340}.Release|Any CPU.Build.0 = Release|Any CPU
+		{465AA074-CAA7-427C-9931-5F81A2548340}.Release|x64.ActiveCfg = Release|Any CPU
+		{465AA074-CAA7-427C-9931-5F81A2548340}.Release|x64.Build.0 = Release|Any CPU
+		{465AA074-CAA7-427C-9931-5F81A2548340}.Release|x86.ActiveCfg = Release|Any CPU
+		{465AA074-CAA7-427C-9931-5F81A2548340}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{DBC4A0DA-8CC2-4957-BEA8-FC6779DAB486} = {E323078B-8911-4000-8307-EAA18941AB37}
+		{465AA074-CAA7-427C-9931-5F81A2548340} = {E323078B-8911-4000-8307-EAA18941AB37}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- **feat: add SAX.TokenParser.Test unit test project**
- **feat: implement single XML character parser**
- **feat: implement XML characters span parser**
- **feat: implement TextSpan.Trim() extension method**
- **feat: implement Trim(l,r) parser closure**
- **feat: implement TrimCData parser**
- **feat: implement TrimComment parser**
- **feat: implement QuotedStringWithQuotes parser**
- **feat: implement QuotedString parser**
- **feat: implement ElementIdentifier parser**
- **feat: implement ElementIdentifier parser for unit tests**
- **feat: define Attribute record structure**
- **feat: implement ElementAttribute parser**
- **feat: implement ElementAttribute parser for unit tests**
- **feat: implement many ElementAttributes parser for unit tests**
- **feat: define Element record structure**
- **feat: implement ElementAndAttributes parser for unit tests**
- **feat: implement ElementStart parser**
- **feat: implement ElementEmpty parser**
- **feat: implement ElementEnd parser**
- **feat: implement unit test for XmlChars parser**
- **feat: implement unit test for TrimCData parser**
- **feat: implement unit test for TrimComment parser**
- **feat: implement unit test for QuotedString parser**
- **feat: implement unit test for ElementIdentifier parser**
- **feat: implement unit test for ElementAttribute parser**
- **feat: implement unit test for ElementAndAttributes parser**
- **feat: implement unit test for ElementStart parser**
- **feat: implement unit test for ElementEmpty parser**
- **feat: implement unit test for ElementEnd parser**
