### PR TITLE
refactor: reduce string copies and memory usage by optimizing SaxParser and IXMLEventHandler to use ReadOnlySpan<char> instead of string


### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <PackageVersion Include="Superpower" Version="3.0.0" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="TurboXml" Version="2.0.2" />
+    <PackageVersion Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 
   <ItemGroup Label="unit test dependencies">

--- a/Tests/SAX.EventHandler.Test/DelegateXMLEventHandler.cs
+++ b/Tests/SAX.EventHandler.Test/DelegateXMLEventHandler.cs
@@ -8,64 +8,64 @@ namespace SAX.EventHandler.Test;
 ///</summary>
 public class DelegateXMLEventHandler : IXMLEventHandler
 {
-    public Action<string, string, string> OnXmlDeclarationCallback = (_, __, ___) =>
+    public Action<ReadOnlySpan<char>, ReadOnlySpan<char>, ReadOnlySpan<char>> OnXmlDeclarationCallback = (_, __, ___) =>
     {
         Assert.False(true);
     };
-    public Action<string> OnElementStartCallback = _ =>
+    public Action<ReadOnlySpan<char>> OnElementStartCallback = _ =>
     {
         Assert.False(true);
     };
-    public Action<string> OnElementEndCallback = _ =>
+    public Action<ReadOnlySpan<char>> OnElementEndCallback = _ =>
     {
         Assert.False(true);
     };
-    public Action<string> OnElementEmptyCallback = _ =>
+    public Action<ReadOnlySpan<char>> OnElementEmptyCallback = _ =>
     {
         Assert.False(true);
     };
-    public Action<string, string?> OnAttributeCallback = (_, __) =>
+    public Action<ReadOnlySpan<char>, ReadOnlySpan<char>> OnAttributeCallback = (_, __) =>
     {
         Assert.False(true);
     };
-    public Action<string, string> OnProcessingInstructionCallback = (_, __) =>
+    public Action<ReadOnlySpan<char>, ReadOnlySpan<char>> OnProcessingInstructionCallback = (_, __) =>
     {
         Assert.False(true);
     };
-    public Action<string> OnCDataCallback = _ =>
+    public Action<ReadOnlySpan<char>> OnCDataCallback = _ =>
     {
         Assert.False(true);
     };
-    public Action<string> OnCommentCallback = _ =>
+    public Action<ReadOnlySpan<char>> OnCommentCallback = _ =>
     {
         Assert.False(true);
     };
-    public Action<string> OnContentCallback = _ =>
+    public Action<ReadOnlySpan<char>> OnContentCallback = _ =>
     {
         Assert.False(true);
     };
-    public Action<string> OnErrorCallback = _ =>
+    public Action<ReadOnlySpan<char>> OnErrorCallback = _ =>
     {
         Assert.False(true);
     };
 
-    public void OnXmlDeclaration(string version, string encoding, string standalone) => OnXmlDeclarationCallback(version, encoding, standalone);
+    public void OnXmlDeclaration(ReadOnlySpan<char> version, ReadOnlySpan<char> encoding, ReadOnlySpan<char> standalone) => OnXmlDeclarationCallback(version, encoding, standalone);
 
-    public void OnElementStart(string name) => OnElementStartCallback(name);
+    public void OnElementStart(ReadOnlySpan<char> name) => OnElementStartCallback(name);
 
-    public void OnElementEnd(string name) => OnElementEndCallback(name);
+    public void OnElementEnd(ReadOnlySpan<char> name) => OnElementEndCallback(name);
 
-    public void OnElementEmpty(string name) => OnElementEmptyCallback(name);
+    public void OnElementEmpty(ReadOnlySpan<char> name) => OnElementEmptyCallback(name);
 
-    public void OnAttribute(string name, string? value) => OnAttributeCallback(name, value);
+    public void OnAttribute(ReadOnlySpan<char> name, ReadOnlySpan<char> value) => OnAttributeCallback(name, value);
 
-    public void OnProcessingInstruction(string name, string value) => OnProcessingInstructionCallback(name, value);
+    public void OnProcessingInstruction(ReadOnlySpan<char> name, ReadOnlySpan<char> value) => OnProcessingInstructionCallback(name, value);
 
-    public void OnCData(string cdata) => OnCDataCallback(cdata);
+    public void OnCData(ReadOnlySpan<char> cdata) => OnCDataCallback(cdata);
 
-    public void OnComment(string comment) => OnCommentCallback(comment);
+    public void OnComment(ReadOnlySpan<char> comment) => OnCommentCallback(comment);
 
-    public void OnContent(string text) => OnContentCallback(text);
+    public void OnContent(ReadOnlySpan<char> text) => OnContentCallback(text);
 
-    public void OnError(string message) => OnErrorCallback(message);
+    public void OnError(ReadOnlySpan<char> message) => OnErrorCallback(message);
 }

--- a/Tests/SAX.EventHandler.Test/OnElementEmptyTest.cs
+++ b/Tests/SAX.EventHandler.Test/OnElementEmptyTest.cs
@@ -85,7 +85,7 @@ public class OnElementEmptyTest
                 OnAttributeCallback = (attributeName, attributeValue) =>
                 {
                     Assert.Equal(expectedAttribute, attributeName);
-                    Assert.Null(attributeValue);
+                    Assert.True(attributeValue.IsEmpty);
                 }
             };
         SaxParser.Parse(input, handler);
@@ -131,8 +131,7 @@ public class OnElementEmptyTest
                 OnAttributeCallback = (attributeName, attributeValue) =>
                 {
                     Assert.Equal(expectedAttribute, attributeName);
-                    Assert.NotNull(attributeValue);
-                    Assert.Empty(attributeValue);
+                    Assert.True(attributeValue.IsEmpty);
                 }
             };
         SaxParser.Parse(input, handler);
@@ -169,8 +168,7 @@ public class OnElementEmptyTest
                 OnAttributeCallback = (attributeName, attributeValue) =>
                 {
                     Assert.Equal(expectedAttribute, attributeName);
-                    Assert.NotNull(attributeValue);
-                    Assert.NotEmpty(attributeValue);
+                    Assert.False(attributeValue.IsEmpty);
                     Assert.Equal(expectedValue, attributeValue);
                 }
             };

--- a/Tests/SAX.EventHandler.Test/OnElementStartTest.cs
+++ b/Tests/SAX.EventHandler.Test/OnElementStartTest.cs
@@ -85,7 +85,7 @@ public class OnElementStartTest
                 OnAttributeCallback = (attributeName, attributeValue) =>
                 {
                     Assert.Equal(expectedAttribute, attributeName);
-                    Assert.Null(attributeValue);
+                    Assert.True(attributeValue.IsEmpty);
                 }
             };
         SaxParser.Parse(input, handler);
@@ -131,8 +131,7 @@ public class OnElementStartTest
                 OnAttributeCallback = (attributeName, attributeValue) =>
                 {
                     Assert.Equal(expectedAttribute, attributeName);
-                    Assert.NotNull(attributeValue);
-                    Assert.Empty(attributeValue);
+                    Assert.True(attributeValue.IsEmpty);
                 }
             };
         SaxParser.Parse(input, handler);
@@ -169,8 +168,7 @@ public class OnElementStartTest
                 OnAttributeCallback = (attributeName, attributeValue) =>
                 {
                     Assert.Equal(expectedAttribute, attributeName);
-                    Assert.NotNull(attributeValue);
-                    Assert.NotEmpty(attributeValue);
+                    Assert.False(attributeValue.IsEmpty);
                     Assert.Equal(expectedValue, attributeValue);
                 }
             };

--- a/Tests/SAX.EventHandler.Test/OnProcessingInstructionTest.cs
+++ b/Tests/SAX.EventHandler.Test/OnProcessingInstructionTest.cs
@@ -18,7 +18,7 @@ public class OnProcessingInstructionTest
                 OnProcessingInstructionCallback = (identifier, contents) =>
                 {
                     Assert.Equal(expected, identifier);
-                    Assert.NotNull(contents);
+                    Assert.False(contents.IsEmpty);
                 }
             };
         SaxParser.Parse(input, handler);
@@ -35,7 +35,7 @@ public class OnProcessingInstructionTest
                 OnProcessingInstructionCallback = (identifier, contents) =>
                 {
                     Assert.Equal(expectedIdentifier, identifier);
-                    Assert.NotNull(contents);
+                    Assert.False(contents.IsEmpty);
                     Assert.Equal(expectedContents, contents.Trim());
                 }
             };

--- a/Tests/SAX.EventHandler.Test/OnXmlDeclarationTest.cs
+++ b/Tests/SAX.EventHandler.Test/OnXmlDeclarationTest.cs
@@ -15,14 +15,11 @@ public class OnXmlDeclarationTest
             {
                 OnXmlDeclarationCallback = (version, encoding, standalone) =>
                 {
-                    Assert.NotNull(version);
-                    Assert.Empty(version);
+                    Assert.True(version.IsEmpty);
 
-                    Assert.NotNull(encoding);
-                    Assert.Empty(encoding);
+                    Assert.True(encoding.IsEmpty);
 
-                    Assert.NotNull(standalone);
-                    Assert.Empty(standalone);
+                    Assert.True(standalone.IsEmpty);
                 }
             };
         SaxParser.Parse(input, handler);
@@ -38,15 +35,11 @@ public class OnXmlDeclarationTest
             {
                 OnXmlDeclarationCallback = (version, encoding, standalone) =>
                 {
-                    Assert.NotNull(version);
-                    Assert.NotEmpty(version);
+                    Assert.False(version.IsEmpty);
                     Assert.Equal(expected, version);
 
-                    Assert.NotNull(encoding);
-                    Assert.Empty(encoding);
-
-                    Assert.NotNull(standalone);
-                    Assert.Empty(standalone);
+                    Assert.True(encoding.IsEmpty);
+                    Assert.True(standalone.IsEmpty);
                 }
             };
         SaxParser.Parse(input, handler);
@@ -62,16 +55,13 @@ public class OnXmlDeclarationTest
             {
                 OnXmlDeclarationCallback = (version, encoding, standalone) =>
                 {
-                    Assert.NotNull(version);
-                    Assert.NotEmpty(version);
+                    Assert.False(version.IsEmpty);
                     Assert.Equal(expectedVersion, version);
 
-                    Assert.NotNull(encoding);
-                    Assert.NotEmpty(encoding);
+                    Assert.False(encoding.IsEmpty);
                     Assert.Equal(expectedEncoding, encoding);
 
-                    Assert.NotNull(standalone);
-                    Assert.Empty(standalone);
+                    Assert.True(standalone.IsEmpty);
                 }
             };
         SaxParser.Parse(input, handler);
@@ -87,16 +77,13 @@ public class OnXmlDeclarationTest
             {
                 OnXmlDeclarationCallback = (version, encoding, standalone) =>
                 {
-                    Assert.NotNull(version);
-                    Assert.NotEmpty(version);
+                    Assert.False(version.IsEmpty);
                     Assert.Equal(expectedVersion, version);
 
-                    Assert.NotNull(encoding);
-                    Assert.NotEmpty(encoding);
+                    Assert.False(encoding.IsEmpty);
                     Assert.Equal(expectedEncoding, encoding);
 
-                    Assert.NotNull(standalone);
-                    Assert.NotEmpty(standalone);
+                    Assert.False(standalone.IsEmpty);
                     Assert.Equal(expectedStandalone, standalone);
                 }
             };
@@ -113,16 +100,13 @@ public class OnXmlDeclarationTest
             {
                 OnXmlDeclarationCallback = (version, encoding, standalone) =>
                 {
-                    Assert.NotNull(version);
-                    Assert.NotEmpty(version);
+                    Assert.False(version.IsEmpty);
                     Assert.Equal(expectedVersion, version);
 
-                    Assert.NotNull(encoding);
-                    Assert.NotEmpty(encoding);
+                    Assert.False(encoding.IsEmpty);
                     Assert.Equal(expectedEncoding, encoding);
 
-                    Assert.NotNull(standalone);
-                    Assert.Empty(standalone);
+                    Assert.True(standalone.IsEmpty);
                 }
             };
         SaxParser.Parse(input, handler);

--- a/XmlFormat.SAX/IXMLEventHandler.cs
+++ b/XmlFormat.SAX/IXMLEventHandler.cs
@@ -7,17 +7,17 @@ namespace XmlFormat.SAX;
 ///</summary>
 public interface IXMLEventHandler
 {
-    void OnXmlDeclaration(string version, string encoding, string standalone);
+    void OnXmlDeclaration(ReadOnlySpan<char> version, ReadOnlySpan<char> encoding, ReadOnlySpan<char> standalone);
 
-    void OnElementStart(string name);
-    void OnElementEnd(string name);
-    void OnElementEmpty(string name);
-    void OnAttribute(string name, string? value);
+    void OnElementStart(ReadOnlySpan<char> name);
+    void OnElementEnd(ReadOnlySpan<char> name);
+    void OnElementEmpty(ReadOnlySpan<char> name);
+    void OnAttribute(ReadOnlySpan<char> name, ReadOnlySpan<char> value);
 
-    void OnProcessingInstruction(string identifier, string contents);
-    void OnCData(string cdata);
-    void OnComment(string comment);
-    void OnContent(string text);
+    void OnProcessingInstruction(ReadOnlySpan<char> identifier, ReadOnlySpan<char> contents);
+    void OnCData(ReadOnlySpan<char> cdata);
+    void OnComment(ReadOnlySpan<char> comment);
+    void OnContent(ReadOnlySpan<char> text);
 
-    void OnError(string message);
+    void OnError(ReadOnlySpan<char> message);
 }

--- a/XmlFormat.SAX/LoggingXMLEventHandler.cs
+++ b/XmlFormat.SAX/LoggingXMLEventHandler.cs
@@ -7,25 +7,26 @@ namespace XmlFormat.SAX;
 ///</summary>
 public class LoggingXMLEventHandler : IXMLEventHandler
 {
-    public virtual void OnXmlDeclaration(string version, string encoding, string standalone) =>
-        Console.WriteLine($"XML Declaration {version}, {encoding}, {standalone}");
+    public virtual void OnXmlDeclaration(ReadOnlySpan<char> version, ReadOnlySpan<char> encoding, ReadOnlySpan<char> standalone) =>
+        Console.WriteLine($"XML Declaration {version.ToString()}, {encoding.ToString()}, {standalone.ToString()}");
 
-    public virtual void OnElementStart(string name) => Console.WriteLine($"XML Element Start `{name}`");
+    public virtual void OnElementStart(ReadOnlySpan<char> name) => Console.WriteLine($"XML Element Start `{name.ToString()}`");
 
-    public virtual void OnElementEnd(string name) => Console.WriteLine($"XML Element End `{name}`");
+    public virtual void OnElementEnd(ReadOnlySpan<char> name) => Console.WriteLine($"XML Element End `{name.ToString()}`");
 
-    public virtual void OnElementEmpty(string name) => Console.WriteLine($"XML Element Empty `{name}`");
+    public virtual void OnElementEmpty(ReadOnlySpan<char> name) => Console.WriteLine($"XML Element Empty `{name.ToString()}`");
 
-    public virtual void OnAttribute(string name, string? value) => Console.WriteLine($"XML Attribute `{name}`:{value}");
+    public virtual void OnAttribute(ReadOnlySpan<char> name, ReadOnlySpan<char> value) =>
+        Console.WriteLine($"XML Attribute `{name.ToString()}`:{value.ToString()}");
 
-    public virtual void OnProcessingInstruction(string identifier, string contents) =>
-        Console.WriteLine($"XML processing instruction `{identifier}`: `{contents}`");
+    public virtual void OnProcessingInstruction(ReadOnlySpan<char> identifier, ReadOnlySpan<char> contents) =>
+        Console.WriteLine($"XML processing instruction `{identifier.ToString()}`: `{contents.ToString()}`");
 
-    public virtual void OnCData(string cdata) => Console.WriteLine($"XML CData `{cdata}`");
+    public virtual void OnCData(ReadOnlySpan<char> cdata) => Console.WriteLine($"XML CData `{cdata.ToString()}`");
 
-    public virtual void OnComment(string comment) => Console.WriteLine($"XML Comment `{comment}`");
+    public virtual void OnComment(ReadOnlySpan<char> comment) => Console.WriteLine($"XML Comment `{comment.ToString()}`");
 
-    public virtual void OnContent(string text) => Console.WriteLine($"XML Content {text}");
+    public virtual void OnContent(ReadOnlySpan<char> text) => Console.WriteLine($"XML Content {text.ToString()}");
 
-    public virtual void OnError(string message) => Console.Error.WriteLine($"XML Error: {message}");
+    public virtual void OnError(ReadOnlySpan<char> message) => Console.Error.WriteLine($"XML Error: {message.ToString()}");
 }

--- a/XmlFormat.SAX/SaxParser.cs
+++ b/XmlFormat.SAX/SaxParser.cs
@@ -1,3 +1,5 @@
+using Superpower.Model;
+
 namespace XmlFormat.SAX;
 
 public static class SaxParser
@@ -11,59 +13,71 @@ public static class SaxParser
                 case XmlTokenizer.XmlToken.Declaration:
                     var tempDeclaration = XmlTokenParser.Declaration(token.Span);
                     handler.OnXmlDeclaration(
-                        tempDeclaration.Value.Version?.ToStringValue() ?? string.Empty,
-                        tempDeclaration.Value.Encoding?.ToStringValue() ?? string.Empty,
-                        tempDeclaration.Value.Standalone?.ToStringValue() ?? string.Empty
+                        tempDeclaration.Value.Version == null
+                            ? ReadOnlySpan<char>.Empty
+                            : ((TextSpan)tempDeclaration.Value.Version!).ToReadOnlySpan(),
+                        tempDeclaration.Value.Encoding == null
+                            ? ReadOnlySpan<char>.Empty
+                            : ((TextSpan)tempDeclaration.Value.Encoding!).ToReadOnlySpan(),
+                        tempDeclaration.Value.Standalone == null
+                            ? ReadOnlySpan<char>.Empty
+                            : ((TextSpan)tempDeclaration.Value.Standalone!).ToReadOnlySpan()
                     );
                     break;
 
                 case XmlTokenizer.XmlToken.ProcessingInstruction:
                     var tempPI = XmlTokenParser.ProcessingInstruction(token.Span);
                     handler.OnProcessingInstruction(
-                        tempPI.Value.Identifier.ToStringValue(),
-                        tempPI.Value.Contents?.ToStringValue() ?? string.Empty
+                        tempPI.Value.Identifier.ToReadOnlySpan(),
+                        tempPI.Value.Contents == null ? ReadOnlySpan<char>.Empty : ((TextSpan)tempPI.Value.Contents!).ToReadOnlySpan()
                     );
                     break;
 
                 case XmlTokenizer.XmlToken.Comment:
                     var tempComment = XmlTokenParser.TrimComment(token.Span);
-                    handler.OnComment(tempComment.Value.ToStringValue());
+                    handler.OnComment(tempComment.Value.ToReadOnlySpan());
                     break;
 
                 case XmlTokenizer.XmlToken.CData:
                     var tempCData = XmlTokenParser.TrimCData(token.Span);
-                    handler.OnCData(tempCData.Value.ToStringValue());
+                    handler.OnCData(tempCData.Value.ToReadOnlySpan());
                     break;
 
                 case XmlTokenizer.XmlToken.ElementStart:
                     var tempElementStart = XmlTokenParser.ElementStart(token.Span);
-                    handler.OnElementStart(tempElementStart.Value.Identifier.ToStringValue());
+                    handler.OnElementStart(tempElementStart.Value.Identifier.ToReadOnlySpan());
                     foreach (var attribute in tempElementStart.Value.Attributes)
                     {
-                        handler.OnAttribute(attribute.Name.ToStringValue(), attribute.Value?.ToStringValue());
+                        handler.OnAttribute(
+                            attribute.Name.ToReadOnlySpan(),
+                            attribute.Value == null ? ReadOnlySpan<char>.Empty : ((TextSpan)attribute.Value!).ToReadOnlySpan()
+                        );
                     }
                     break;
 
                 case XmlTokenizer.XmlToken.ElementEmpty:
                     var tempElementEmpty = XmlTokenParser.ElementEmpty(token.Span);
-                    handler.OnElementEmpty(tempElementEmpty.Value.Identifier.ToStringValue());
+                    handler.OnElementEmpty(tempElementEmpty.Value.Identifier.ToReadOnlySpan());
                     foreach (var attribute in tempElementEmpty.Value.Attributes)
                     {
-                        handler.OnAttribute(attribute.Name.ToStringValue(), attribute.Value?.ToStringValue());
+                        handler.OnAttribute(
+                            attribute.Name.ToReadOnlySpan(),
+                            attribute.Value == null ? ReadOnlySpan<char>.Empty : ((TextSpan)attribute.Value!).ToReadOnlySpan()
+                        );
                     }
                     break;
 
                 case XmlTokenizer.XmlToken.ElementEnd:
                     var tempElementEnd = XmlTokenParser.ElementEnd(token.Span);
-                    handler.OnElementEnd(tempElementEnd.Value.ToStringValue());
+                    handler.OnElementEnd(tempElementEnd.Value.ToReadOnlySpan());
                     break;
 
                 case XmlTokenizer.XmlToken.Content:
-                    handler.OnContent(token.Span.ToStringValue());
+                    handler.OnContent(token.Span.ToReadOnlySpan());
                     break;
 
                 default:
-                    handler.OnError(token.Span.ToStringValue());
+                    handler.OnError(token.Span.ToReadOnlySpan());
                     break;
             }
         }

--- a/XmlFormat.SAX/TextSpanToReadOnlySpanExtension.cs
+++ b/XmlFormat.SAX/TextSpanToReadOnlySpanExtension.cs
@@ -1,0 +1,9 @@
+using System;
+using Superpower.Model;
+
+namespace XmlFormat.SAX;
+
+public static class TextSpanToReadOnlySpanExtension
+{
+    public static ReadOnlySpan<char> ToReadOnlySpan(this TextSpan span) => span.Source!.AsSpan().Slice(span.Position.Absolute, span.Length);
+}

--- a/XmlFormat.SAX/XmlFormat.SAX.csproj
+++ b/XmlFormat.SAX/XmlFormat.SAX.csproj
@@ -18,6 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Superpower" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- **build: add package reference to System.Memory v4.6.3**
  

- **feat: implement Superpower.Model.TextSpan.ToReadOnlySpan() extension method**
  

- **refactor: adapt IXMLEventHandler interface methods to take ReadOnlySpan<char> instead of string**
  reason: reduce string copies
  

- **refactor: adapt SaxParser to pass ReadOnlySpan<char> instead of string to IXMLEventHandler**
  reason: reduce string copies
  

- **refactor: adapt LoggingXMLEventHandler to IXMLEventHandler interface methods changes**
  i.e. ReadOnlySpan<char> instead of string
  
  reason: reduce string copies
  

- **refactor: adapt DelegateXMLEventHandler to IXMLEventHandler interface methods changes**
  i.e. ReadOnlySpan<char> instead of string
  
  reason: reduce string copies
  

- **refactor: adapt OnElementEmptyTest to ReadOnlySpan<char> callbacks**
  

- **refactor: adapt OnElementStartTest to ReadOnlySpan<char> callbacks**
  

- **refactor: adapt OnProcessingInstructionTest to ReadOnlySpan<char> callbacks**
  

- **refactor: adapt OnXmlDeclarationTest to ReadOnlySpan<char> callbacks**
  