### PR TITLE
refactor: load XmlFormat.Tool configuration and respect it in FormattingXmlReadHandler

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
   <ItemGroup Label="hosting dependencies">
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup Label="functionality dependencies">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,6 +2,7 @@
 
   <ItemGroup Label="hosting dependencies">
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.4" />
   </ItemGroup>
 
   <ItemGroup Label="functionality dependencies">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,5 +1,9 @@
 <Project>
 
+  <ItemGroup Label="hosting dependencies">
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
+  </ItemGroup>
+
   <ItemGroup Label="functionality dependencies">
     <PackageVersion Include="Superpower" Version="3.0.0" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.4" />
+    <PackageVersion Include="Alexinea.Extensions.Configuration.Toml" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="functionality dependencies">

--- a/XmlFormat.Lib/FormattingOptions.cs
+++ b/XmlFormat.Lib/FormattingOptions.cs
@@ -1,0 +1,3 @@
+namespace XmlFormat;
+
+public record class FormattingOptions(int LineLength, string Tabs, int TabsRepeat);

--- a/XmlFormat.Lib/FormattingXmlReadHandler.cs
+++ b/XmlFormat.Lib/FormattingXmlReadHandler.cs
@@ -67,7 +67,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         : base(streamWriter)
     {
         this.Options = options;
-        this.textWriter = new IndentedTextWriter(writer, tabString: "".PadLeft(2)); //TODO param
+        this.textWriter = new IndentedTextWriter(writer, tabString: Options.Tabs.Repeat(Options.TabsRepeat));
     }
 
     protected override void Dispose(bool disposing)
@@ -109,7 +109,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         if (currentAttributes != null)
         {
             currentAttributes.Sort(Attribute.Compare);
-            if (currentAttributes.SingleLineLength() > 80) //TODO param
+            if (currentAttributes.SingleLineLength() > Options.LineLength)
             {
                 textWriter.WriteLine("");
                 textWriter.Indent++;
@@ -141,7 +141,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
     public override void OnEndTagEmpty()
     {
         requireClosingPreviousElementTag = false;
-        bool multiLineAttributes = currentAttributes?.SingleLineLength() > 80; // TODO param
+        bool multiLineAttributes = currentAttributes?.SingleLineLength() > Options.LineLength;
         OnBeginTagClose();
         textWriter.Indent--;
 
@@ -184,7 +184,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         if (requireClosingPreviousElementTag)
             OnBeginTagClose();
 
-        if (comment.Length < 80) // TODO param
+        if (comment.Length < Options.LineLength)
         {
             textWriter.WriteLine($"<!-- {comment.Trim()} -->");
         }

--- a/XmlFormat.Lib/FormattingXmlReadHandler.cs
+++ b/XmlFormat.Lib/FormattingXmlReadHandler.cs
@@ -8,6 +8,8 @@ namespace XmlFormat;
 
 public class FormattingXmlReadHandler : XmlReadHandlerBase
 {
+    public FormattingOptions Options { get; private set; }
+
     public readonly record struct Attribute(string Name, string Value)
     {
         const string xmlns = "xmlns";
@@ -58,12 +60,13 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
     private bool requireClosingPreviousElementTag = false;
     private List<Attribute>? currentAttributes = default;
 
-    public FormattingXmlReadHandler(Stream stream, Encoding encoding)
-        : this(new StreamWriter(stream, encoding) { AutoFlush = true, }) { }
+    public FormattingXmlReadHandler(Stream stream, Encoding encoding, FormattingOptions options)
+        : this(new StreamWriter(stream, encoding) { AutoFlush = true, }, options) { }
 
-    public FormattingXmlReadHandler(StreamWriter streamWriter)
+    public FormattingXmlReadHandler(StreamWriter streamWriter, FormattingOptions options)
         : base(streamWriter)
     {
+        this.Options = options;
         this.textWriter = new IndentedTextWriter(writer, tabString: "".PadLeft(2)); //TODO param
     }
 

--- a/XmlFormat.Lib/StringRepeatExtensions.cs
+++ b/XmlFormat.Lib/StringRepeatExtensions.cs
@@ -1,0 +1,14 @@
+namespace XmlFormat;
+
+public static class StringRepeatExtensions
+{
+    public static string Repeat(this string s, int n)
+    {
+        return new String(Enumerable.Range(0, n).SelectMany(x => s).ToArray());
+    }
+
+    public static string Repeat(this char c, int n)
+    {
+        return new String(c, n);
+    }
+}

--- a/XmlFormat.Lib/XmlFormat.cs
+++ b/XmlFormat.Lib/XmlFormat.cs
@@ -6,20 +6,21 @@ namespace XmlFormat;
 
 public static class XmlFormat
 {
-    public static void Format(Stream inputStream, Stream outputStream)
+    public static void Format(Stream inputStream, Stream outputStream, FormattingOptions options)
     {
         using var handler = new FormattingXmlReadHandler(
             stream: outputStream,
-            encoding: Encoding.UTF8
+            encoding: Encoding.UTF8,
+            options: options
         );
         XmlParser.Parse(inputStream, handler);
     }
 
-    public static string Format(string xml)
+    public static string Format(string xml, FormattingOptions options)
     {
         using Stream xmlStream = new MemoryStream(Encoding.UTF8.GetBytes(xml) ?? new byte[0]);
         using Stream outStream = new MemoryStream();
-        Format(inputStream: xmlStream, outputStream: outStream);
+        Format(inputStream: xmlStream, outputStream: outStream, options: options);
         return outStream.ToString() ?? "";
     }
 }

--- a/XmlFormat.Tool/Program.cs
+++ b/XmlFormat.Tool/Program.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using System.Text;
 using CommandLine;
+using Microsoft.Extensions.Configuration;
 using TurboXml;
 using XmlFormat;
 
@@ -27,6 +28,10 @@ public class Program
 
     static void RunOptions(Options options)
     {
+        IConfiguration config = new ConfigurationBuilder()
+            .AddTomlFile(Path.Join(AppDomain.CurrentDomain.BaseDirectory, "xmlformat.toml"), optional: false, reloadOnChange: true)
+            .Build();
+
         Console.WriteLine($"options.Inline: {options.Inline}");
         Console.WriteLine($"options.InputFile: {options.InputFile}");
 

--- a/XmlFormat.Tool/Program.cs
+++ b/XmlFormat.Tool/Program.cs
@@ -42,7 +42,7 @@ public class Program
 
         using var istream = OpenInputStreamOrStdIn(options);
         using var ostream = OpenOutputStreamOrStdOut(options);
-        XmlFormat.Format(istream, ostream);
+        XmlFormat.Format(istream, ostream, options: formattingOptions);
     }
 
     static void HandleParseError(IEnumerable<Error> errs)

--- a/XmlFormat.Tool/Program.cs
+++ b/XmlFormat.Tool/Program.cs
@@ -30,6 +30,7 @@ public class Program
     {
         IConfiguration config = new ConfigurationBuilder()
             .AddTomlFile(Path.Join(AppDomain.CurrentDomain.BaseDirectory, "xmlformat.toml"), optional: false, reloadOnChange: true)
+            .AddTomlFile(Path.Join(Environment.CurrentDirectory, ".xmlformat"), optional: true, reloadOnChange: true)
             .Build();
 
         Console.WriteLine($"options.Inline: {options.Inline}");

--- a/XmlFormat.Tool/Program.cs
+++ b/XmlFormat.Tool/Program.cs
@@ -36,6 +36,10 @@ public class Program
         Console.WriteLine($"options.Inline: {options.Inline}");
         Console.WriteLine($"options.InputFile: {options.InputFile}");
 
+        FormattingOptions formattingOptions = new(240, " ", 4);
+        config.Bind(formattingOptions);
+        Console.WriteLine($"formattingOptions: {formattingOptions}");
+
         using var istream = OpenInputStreamOrStdIn(options);
         using var ostream = OpenOutputStreamOrStdOut(options);
         XmlFormat.Format(istream, ostream);

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="package references">
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="TurboXml" />
   </ItemGroup>

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="TurboXml" />
   </ItemGroup>

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -32,4 +32,8 @@
     <ProjectReference Include="..\XmlFormat.Lib\XmlFormat.Lib.csproj" />
   </ItemGroup>
 
+  <ItemGroup Label="configuration files">
+    <Content Include="$(MSBuildThisFileDirectory)\xmlformat.toml" Link="xmlformat.toml" Pack="true" CopyToOutputDirectory="PreserveNewest" PackagePath="\" />
+  </ItemGroup>
+
 </Project>

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup Label="package references">
     <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="TurboXml" />
   </ItemGroup>

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -22,6 +22,7 @@
   <ItemGroup Label="package references">
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="TurboXml" />
   </ItemGroup>

--- a/XmlFormat.Tool/xmlformat.toml
+++ b/XmlFormat.Tool/xmlformat.toml
@@ -1,0 +1,4 @@
+lineLength = 80
+tabs = '  ' #< that's 2 spaces. use '	' to insert tabulators
+tabsRepeat = 1
+


### PR DESCRIPTION
- **build: add package reference to Microsoft.Extensions.Configuration v9.0.4**
- **build: add package reference to Microsoft.Extensions.Configuration.Abstractions v9.0.4**
- **build: add package reference to Microsoft.Extensions.Configuration.Binder v9.0.4**
- **build: add package reference to Alexinea.Extensions.Configuration.Toml v7.0.0**
- **build: bundle xmlformat.toml with XmlFormat.Tool**
- **feat: load required configuration from app-installation-directory/xmlformat.toml**
- **feat: load optional configuration from current-directory/.xmlformat**
- **feat: define record class FormattingOptions**
- **feat: implement string.Repeat() extension method**
- **feat: add FormattingOptions instance to FormattingXmlReadHandler**
- **feat: bind FormattingOptions to configuration**
- **feat: pass FormattingOptions to XmlFormat.Format()**
- **refactor: replace hardcoded values -> FormattingOptions in FormattingXmlReadHandler**
