### PR TITLE
refactor: adapt IXMLEventHandler to method parity with TurboXML equivalent

### DIFF
--- a/Tests/SAX.EventHandler.Test/DelegateXMLEventHandler.cs
+++ b/Tests/SAX.EventHandler.Test/DelegateXMLEventHandler.cs
@@ -8,64 +8,64 @@ namespace SAX.EventHandler.Test;
 ///</summary>
 public class DelegateXMLEventHandler : IXMLEventHandler
 {
-    public Action<ReadOnlySpan<char>, ReadOnlySpan<char>, ReadOnlySpan<char>> OnXmlDeclarationCallback = (_, __, ___) =>
+    public Action<ReadOnlySpan<char>, ReadOnlySpan<char>, ReadOnlySpan<char>, int, int> OnXmlDeclarationCallback = (_, __, ___, line, column) =>
     {
         Assert.False(true);
     };
-    public Action<ReadOnlySpan<char>> OnElementStartCallback = _ =>
+    public Action<ReadOnlySpan<char>, int, int> OnElementStartCallback = (_, line, column) =>
     {
         Assert.False(true);
     };
-    public Action<ReadOnlySpan<char>> OnElementEndCallback = _ =>
+    public Action<ReadOnlySpan<char>, int, int> OnElementEndCallback = (_, line, column) =>
     {
         Assert.False(true);
     };
-    public Action<ReadOnlySpan<char>> OnElementEmptyCallback = _ =>
+    public Action<ReadOnlySpan<char>, int, int> OnElementEmptyCallback = (_, line, column) =>
     {
         Assert.False(true);
     };
-    public Action<ReadOnlySpan<char>, ReadOnlySpan<char>> OnAttributeCallback = (_, __) =>
+    public Action<ReadOnlySpan<char>, ReadOnlySpan<char>, int, int, int, int> OnAttributeCallback = (_, __, nameLine, nameColumn, valueLine, valueColumn) =>
     {
         Assert.False(true);
     };
-    public Action<ReadOnlySpan<char>, ReadOnlySpan<char>> OnProcessingInstructionCallback = (_, __) =>
+    public Action<ReadOnlySpan<char>, ReadOnlySpan<char>, int, int> OnProcessingInstructionCallback = (_, __, line, column) =>
     {
         Assert.False(true);
     };
-    public Action<ReadOnlySpan<char>> OnCDataCallback = _ =>
+    public Action<ReadOnlySpan<char>, int, int> OnCDataCallback = (_, line, column) =>
     {
         Assert.False(true);
     };
-    public Action<ReadOnlySpan<char>> OnCommentCallback = _ =>
+    public Action<ReadOnlySpan<char>, int, int> OnCommentCallback = (_, line, column) =>
     {
         Assert.False(true);
     };
-    public Action<ReadOnlySpan<char>> OnTextCallback = _ =>
+    public Action<ReadOnlySpan<char>, int, int> OnTextCallback = (_, line, column) =>
     {
         Assert.False(true);
     };
-    public Action<ReadOnlySpan<char>> OnErrorCallback = _ =>
+    public Action<string, int, int> OnErrorCallback = (_, line, column) =>
     {
         Assert.False(true);
     };
 
-    public void OnXmlDeclaration(ReadOnlySpan<char> version, ReadOnlySpan<char> encoding, ReadOnlySpan<char> standalone) => OnXmlDeclarationCallback(version, encoding, standalone);
+    public void OnXmlDeclaration(ReadOnlySpan<char> version, ReadOnlySpan<char> encoding, ReadOnlySpan<char> standalone, int line, int column) => OnXmlDeclarationCallback(version, encoding, standalone, line, column);
 
-    public void OnElementStart(ReadOnlySpan<char> name) => OnElementStartCallback(name);
+    public void OnElementStart(ReadOnlySpan<char> name, int line, int column) => OnElementStartCallback(name, line, column);
 
-    public void OnElementEnd(ReadOnlySpan<char> name) => OnElementEndCallback(name);
+    public void OnElementEnd(ReadOnlySpan<char> name, int line, int column) => OnElementEndCallback(name, line, column);
 
-    public void OnElementEmpty(ReadOnlySpan<char> name) => OnElementEmptyCallback(name);
+    public void OnElementEmpty(ReadOnlySpan<char> name, int line, int column) => OnElementEmptyCallback(name, line, column);
 
-    public void OnAttribute(ReadOnlySpan<char> name, ReadOnlySpan<char> value) => OnAttributeCallback(name, value);
+    public void OnAttribute(ReadOnlySpan<char> name, ReadOnlySpan<char> value, int nameLine, int nameColumn, int valueLine, int valueColumn) => OnAttributeCallback(name, value, nameLine, nameColumn, valueLine, valueColumn);
 
-    public void OnProcessingInstruction(ReadOnlySpan<char> name, ReadOnlySpan<char> value) => OnProcessingInstructionCallback(name, value);
+    public void OnProcessingInstruction(ReadOnlySpan<char> name, ReadOnlySpan<char> value, int line, int column) => OnProcessingInstructionCallback(name, value, line, column);
 
-    public void OnCData(ReadOnlySpan<char> cdata) => OnCDataCallback(cdata);
+    public void OnCData(ReadOnlySpan<char> cdata, int line, int column) => OnCDataCallback(cdata, line, column);
 
-    public void OnComment(ReadOnlySpan<char> comment) => OnCommentCallback(comment);
+    public void OnComment(ReadOnlySpan<char> comment, int line, int column) => OnCommentCallback(comment, line, column);
 
-    public void OnText(ReadOnlySpan<char> text) => OnTextCallback(text);
+    public void OnText(ReadOnlySpan<char> text, int line, int column) => OnTextCallback(text, line, column);
 
-    public void OnError(ReadOnlySpan<char> message) => OnErrorCallback(message);
+    public void OnError(string message, int line, int column) => OnErrorCallback(message, line, column);
 }

--- a/Tests/SAX.EventHandler.Test/DelegateXMLEventHandler.cs
+++ b/Tests/SAX.EventHandler.Test/DelegateXMLEventHandler.cs
@@ -40,7 +40,7 @@ public class DelegateXMLEventHandler : IXMLEventHandler
     {
         Assert.False(true);
     };
-    public Action<ReadOnlySpan<char>> OnContentCallback = _ =>
+    public Action<ReadOnlySpan<char>> OnTextCallback = _ =>
     {
         Assert.False(true);
     };
@@ -65,7 +65,7 @@ public class DelegateXMLEventHandler : IXMLEventHandler
 
     public void OnComment(ReadOnlySpan<char> comment) => OnCommentCallback(comment);
 
-    public void OnContent(ReadOnlySpan<char> text) => OnContentCallback(text);
+    public void OnText(ReadOnlySpan<char> text) => OnTextCallback(text);
 
     public void OnError(ReadOnlySpan<char> message) => OnErrorCallback(message);
 }

--- a/Tests/SAX.EventHandler.Test/OnCDataTest.cs
+++ b/Tests/SAX.EventHandler.Test/OnCDataTest.cs
@@ -21,7 +21,7 @@ public class OnCDataTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnCDataCallback = cdata =>
+                OnCDataCallback = (cdata, line, column) =>
                 {
                     Assert.Equal(expected, cdata);
                 }

--- a/Tests/SAX.EventHandler.Test/OnCommentTest.cs
+++ b/Tests/SAX.EventHandler.Test/OnCommentTest.cs
@@ -21,7 +21,7 @@ public class OnCommentTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnCommentCallback = comment =>
+                OnCommentCallback = (comment, line, column) =>
                 {
                     Assert.Equal(expected, comment);
                 }

--- a/Tests/SAX.EventHandler.Test/OnElementEmptyTest.cs
+++ b/Tests/SAX.EventHandler.Test/OnElementEmptyTest.cs
@@ -37,7 +37,7 @@ public class OnElementEmptyTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnElementEmptyCallback = elementIdentifier =>
+                OnElementEmptyCallback = (elementIdentifier, line, column) =>
                 {
                     Assert.Equal(expected, elementIdentifier);
                 }
@@ -78,11 +78,11 @@ public class OnElementEmptyTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnElementEmptyCallback = elementIdentifier =>
+                OnElementEmptyCallback = (elementIdentifier, line, column) =>
                 {
                     Assert.Equal(expectedElement, elementIdentifier);
                 },
-                OnAttributeCallback = (attributeName, attributeValue) =>
+                OnAttributeCallback = (attributeName, attributeValue, nameLine, nameColumn, valueLine, valueLolumn) =>
                 {
                     Assert.Equal(expectedAttribute, attributeName);
                     Assert.True(attributeValue.IsEmpty);
@@ -124,11 +124,11 @@ public class OnElementEmptyTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnElementEmptyCallback = elementIdentifier =>
+                OnElementEmptyCallback = (elementIdentifier, line, column) =>
                 {
                     Assert.Equal(expectedElement, elementIdentifier);
                 },
-                OnAttributeCallback = (attributeName, attributeValue) =>
+                OnAttributeCallback = (attributeName, attributeValue, nameLine, nameColumn, valueLine, valueLolumn) =>
                 {
                     Assert.Equal(expectedAttribute, attributeName);
                     Assert.True(attributeValue.IsEmpty);
@@ -161,11 +161,11 @@ public class OnElementEmptyTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnElementEmptyCallback = elementIdentifier =>
+                OnElementEmptyCallback = (elementIdentifier, line, column) =>
                 {
                     Assert.Equal(expectedElement, elementIdentifier);
                 },
-                OnAttributeCallback = (attributeName, attributeValue) =>
+                OnAttributeCallback = (attributeName, attributeValue, nameLine, nameColumn, valueLine, valueLolumn) =>
                 {
                     Assert.Equal(expectedAttribute, attributeName);
                     Assert.False(attributeValue.IsEmpty);

--- a/Tests/SAX.EventHandler.Test/OnElementEndTest.cs
+++ b/Tests/SAX.EventHandler.Test/OnElementEndTest.cs
@@ -37,9 +37,9 @@ public class OnElementEndTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnElementEndCallback = cdata =>
+                OnElementEndCallback = (element, line, column) =>
                 {
-                    Assert.Equal(expected, cdata);
+                    Assert.Equal(expected, element);
                 }
             };
         SaxParser.Parse(input, handler);

--- a/Tests/SAX.EventHandler.Test/OnElementStartTest.cs
+++ b/Tests/SAX.EventHandler.Test/OnElementStartTest.cs
@@ -37,7 +37,7 @@ public class OnElementStartTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnElementStartCallback = elementIdentifier =>
+                OnElementStartCallback = (elementIdentifier, line, column) =>
                 {
                     Assert.Equal(expected, elementIdentifier);
                 }
@@ -78,11 +78,11 @@ public class OnElementStartTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnElementStartCallback = elementIdentifier =>
+                OnElementStartCallback = (elementIdentifier, line, column) =>
                 {
                     Assert.Equal(expectedElement, elementIdentifier);
                 },
-                OnAttributeCallback = (attributeName, attributeValue) =>
+                OnAttributeCallback = (attributeName, attributeValue, nameLine, nameColumn, valueLine, valueLolumn) =>
                 {
                     Assert.Equal(expectedAttribute, attributeName);
                     Assert.True(attributeValue.IsEmpty);
@@ -124,11 +124,11 @@ public class OnElementStartTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnElementStartCallback = elementIdentifier =>
+                OnElementStartCallback = (elementIdentifier, line, column) =>
                 {
                     Assert.Equal(expectedElement, elementIdentifier);
                 },
-                OnAttributeCallback = (attributeName, attributeValue) =>
+                OnAttributeCallback = (attributeName, attributeValue, nameLine, nameColumn, valueLine, valueLolumn) =>
                 {
                     Assert.Equal(expectedAttribute, attributeName);
                     Assert.True(attributeValue.IsEmpty);
@@ -161,11 +161,11 @@ public class OnElementStartTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnElementStartCallback = elementIdentifier =>
+                OnElementStartCallback = (elementIdentifier, line, column) =>
                 {
                     Assert.Equal(expectedElement, elementIdentifier);
                 },
-                OnAttributeCallback = (attributeName, attributeValue) =>
+                OnAttributeCallback = (attributeName, attributeValue, nameLine, nameColumn, valueLine, valueLolumn) =>
                 {
                     Assert.Equal(expectedAttribute, attributeName);
                     Assert.False(attributeValue.IsEmpty);

--- a/Tests/SAX.EventHandler.Test/OnProcessingInstructionTest.cs
+++ b/Tests/SAX.EventHandler.Test/OnProcessingInstructionTest.cs
@@ -15,7 +15,7 @@ public class OnProcessingInstructionTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnProcessingInstructionCallback = (identifier, contents) =>
+                OnProcessingInstructionCallback = (identifier, contents, line, column) =>
                 {
                     Assert.Equal(expected, identifier);
                     Assert.False(contents.IsEmpty);
@@ -32,7 +32,7 @@ public class OnProcessingInstructionTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnProcessingInstructionCallback = (identifier, contents) =>
+                OnProcessingInstructionCallback = (identifier, contents, line, column) =>
                 {
                     Assert.Equal(expectedIdentifier, identifier);
                     Assert.False(contents.IsEmpty);

--- a/Tests/SAX.EventHandler.Test/OnXmlDeclarationTest.cs
+++ b/Tests/SAX.EventHandler.Test/OnXmlDeclarationTest.cs
@@ -13,7 +13,7 @@ public class OnXmlDeclarationTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnXmlDeclarationCallback = (version, encoding, standalone) =>
+                OnXmlDeclarationCallback = (version, encoding, standalone, line, column) =>
                 {
                     Assert.True(version.IsEmpty);
 
@@ -33,7 +33,7 @@ public class OnXmlDeclarationTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnXmlDeclarationCallback = (version, encoding, standalone) =>
+                OnXmlDeclarationCallback = (version, encoding, standalone, line, column) =>
                 {
                     Assert.False(version.IsEmpty);
                     Assert.Equal(expected, version);
@@ -53,7 +53,7 @@ public class OnXmlDeclarationTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnXmlDeclarationCallback = (version, encoding, standalone) =>
+                OnXmlDeclarationCallback = (version, encoding, standalone, line, column) =>
                 {
                     Assert.False(version.IsEmpty);
                     Assert.Equal(expectedVersion, version);
@@ -75,7 +75,7 @@ public class OnXmlDeclarationTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnXmlDeclarationCallback = (version, encoding, standalone) =>
+                OnXmlDeclarationCallback = (version, encoding, standalone, line, column) =>
                 {
                     Assert.False(version.IsEmpty);
                     Assert.Equal(expectedVersion, version);
@@ -98,7 +98,7 @@ public class OnXmlDeclarationTest
         DelegateXMLEventHandler handler =
             new()
             {
-                OnXmlDeclarationCallback = (version, encoding, standalone) =>
+                OnXmlDeclarationCallback = (version, encoding, standalone, line, column) =>
                 {
                     Assert.False(version.IsEmpty);
                     Assert.Equal(expectedVersion, version);

--- a/XmlFormat.SAX/IXMLEventHandler.cs
+++ b/XmlFormat.SAX/IXMLEventHandler.cs
@@ -19,5 +19,5 @@ public interface IXMLEventHandler
     void OnComment(ReadOnlySpan<char> comment, int line, int column);
     void OnText(ReadOnlySpan<char> text, int line, int column);
 
-    void OnError(ReadOnlySpan<char> message);
+    void OnError(string message, int line, int column);
 }

--- a/XmlFormat.SAX/IXMLEventHandler.cs
+++ b/XmlFormat.SAX/IXMLEventHandler.cs
@@ -7,17 +7,17 @@ namespace XmlFormat.SAX;
 ///</summary>
 public interface IXMLEventHandler
 {
-    void OnXmlDeclaration(ReadOnlySpan<char> version, ReadOnlySpan<char> encoding, ReadOnlySpan<char> standalone);
+    void OnXmlDeclaration(ReadOnlySpan<char> version, ReadOnlySpan<char> encoding, ReadOnlySpan<char> standalone, int line, int column);
 
-    void OnElementStart(ReadOnlySpan<char> name);
-    void OnElementEnd(ReadOnlySpan<char> name);
-    void OnElementEmpty(ReadOnlySpan<char> name);
-    void OnAttribute(ReadOnlySpan<char> name, ReadOnlySpan<char> value);
+    void OnElementStart(ReadOnlySpan<char> name, int line, int column);
+    void OnElementEnd(ReadOnlySpan<char> name, int line, int column);
+    void OnElementEmpty(ReadOnlySpan<char> name, int line, int column);
+    void OnAttribute(ReadOnlySpan<char> name, ReadOnlySpan<char> value, int line, int column);
 
-    void OnProcessingInstruction(ReadOnlySpan<char> identifier, ReadOnlySpan<char> contents);
-    void OnCData(ReadOnlySpan<char> cdata);
-    void OnComment(ReadOnlySpan<char> comment);
-    void OnText(ReadOnlySpan<char> text);
+    void OnProcessingInstruction(ReadOnlySpan<char> identifier, ReadOnlySpan<char> contents, int line, int column);
+    void OnCData(ReadOnlySpan<char> cdata, int line, int column);
+    void OnComment(ReadOnlySpan<char> comment, int line, int column);
+    void OnText(ReadOnlySpan<char> text, int line, int column);
 
     void OnError(ReadOnlySpan<char> message);
 }

--- a/XmlFormat.SAX/IXMLEventHandler.cs
+++ b/XmlFormat.SAX/IXMLEventHandler.cs
@@ -12,7 +12,7 @@ public interface IXMLEventHandler
     void OnElementStart(ReadOnlySpan<char> name, int line, int column);
     void OnElementEnd(ReadOnlySpan<char> name, int line, int column);
     void OnElementEmpty(ReadOnlySpan<char> name, int line, int column);
-    void OnAttribute(ReadOnlySpan<char> name, ReadOnlySpan<char> value, int line, int column);
+    void OnAttribute(ReadOnlySpan<char> name, ReadOnlySpan<char> value, int nameLine, int nameColumn, int valueLine, int valueColumn);
 
     void OnProcessingInstruction(ReadOnlySpan<char> identifier, ReadOnlySpan<char> contents, int line, int column);
     void OnCData(ReadOnlySpan<char> cdata, int line, int column);

--- a/XmlFormat.SAX/IXMLEventHandler.cs
+++ b/XmlFormat.SAX/IXMLEventHandler.cs
@@ -17,7 +17,7 @@ public interface IXMLEventHandler
     void OnProcessingInstruction(ReadOnlySpan<char> identifier, ReadOnlySpan<char> contents);
     void OnCData(ReadOnlySpan<char> cdata);
     void OnComment(ReadOnlySpan<char> comment);
-    void OnContent(ReadOnlySpan<char> text);
+    void OnText(ReadOnlySpan<char> text);
 
     void OnError(ReadOnlySpan<char> message);
 }

--- a/XmlFormat.SAX/LoggingXMLEventHandler.cs
+++ b/XmlFormat.SAX/LoggingXMLEventHandler.cs
@@ -26,7 +26,7 @@ public class LoggingXMLEventHandler : IXMLEventHandler
 
     public virtual void OnComment(ReadOnlySpan<char> comment) => Console.WriteLine($"XML Comment `{comment.ToString()}`");
 
-    public virtual void OnContent(ReadOnlySpan<char> text) => Console.WriteLine($"XML Content {text.ToString()}");
+    public virtual void OnText(ReadOnlySpan<char> text) => Console.WriteLine($"XML Content {text.ToString()}");
 
     public virtual void OnError(ReadOnlySpan<char> message) => Console.Error.WriteLine($"XML Error: {message.ToString()}");
 }

--- a/XmlFormat.SAX/LoggingXMLEventHandler.cs
+++ b/XmlFormat.SAX/LoggingXMLEventHandler.cs
@@ -7,26 +7,43 @@ namespace XmlFormat.SAX;
 ///</summary>
 public class LoggingXMLEventHandler : IXMLEventHandler
 {
-    public virtual void OnXmlDeclaration(ReadOnlySpan<char> version, ReadOnlySpan<char> encoding, ReadOnlySpan<char> standalone) =>
-        Console.WriteLine($"XML Declaration {version.ToString()}, {encoding.ToString()}, {standalone.ToString()}");
+    public virtual void OnXmlDeclaration(
+        ReadOnlySpan<char> version,
+        ReadOnlySpan<char> encoding,
+        ReadOnlySpan<char> standalone,
+        int line,
+        int column
+    ) => Console.WriteLine($"XML Declaration {version.ToString()}, {encoding.ToString()}, {standalone.ToString()}, {line}:{column}");
 
-    public virtual void OnElementStart(ReadOnlySpan<char> name) => Console.WriteLine($"XML Element Start `{name.ToString()}`");
+    public virtual void OnElementStart(ReadOnlySpan<char> name, int line, int column) =>
+        Console.WriteLine($"XML Element Start `{name.ToString()}`, {line}:{column}");
 
-    public virtual void OnElementEnd(ReadOnlySpan<char> name) => Console.WriteLine($"XML Element End `{name.ToString()}`");
+    public virtual void OnElementEnd(ReadOnlySpan<char> name, int line, int column) =>
+        Console.WriteLine($"XML Element End `{name.ToString()}`, {line}:{column}");
 
-    public virtual void OnElementEmpty(ReadOnlySpan<char> name) => Console.WriteLine($"XML Element Empty `{name.ToString()}`");
+    public virtual void OnElementEmpty(ReadOnlySpan<char> name, int line, int column) =>
+        Console.WriteLine($"XML Element Empty `{name.ToString()}`, {line}:{column}");
 
-    public virtual void OnAttribute(ReadOnlySpan<char> name, ReadOnlySpan<char> value) =>
-        Console.WriteLine($"XML Attribute `{name.ToString()}`:{value.ToString()}");
+    public virtual void OnAttribute(
+        ReadOnlySpan<char> name,
+        ReadOnlySpan<char> value,
+        int nameLine,
+        int nameColumn,
+        int valueLine,
+        int valueColumn
+    ) => Console.WriteLine($"XML Attribute `{name.ToString()}`:{value.ToString()}, {nameLine}:{nameColumn}, {valueLine}:{valueColumn}");
 
-    public virtual void OnProcessingInstruction(ReadOnlySpan<char> identifier, ReadOnlySpan<char> contents) =>
-        Console.WriteLine($"XML processing instruction `{identifier.ToString()}`: `{contents.ToString()}`");
+    public virtual void OnProcessingInstruction(ReadOnlySpan<char> identifier, ReadOnlySpan<char> contents, int line, int column) =>
+        Console.WriteLine($"XML processing instruction `{identifier.ToString()}`: `{contents.ToString()}`, {line}:{column}");
 
-    public virtual void OnCData(ReadOnlySpan<char> cdata) => Console.WriteLine($"XML CData `{cdata.ToString()}`");
+    public virtual void OnCData(ReadOnlySpan<char> cdata, int line, int column) =>
+        Console.WriteLine($"XML CData `{cdata.ToString()}`, {line}:{column}");
 
-    public virtual void OnComment(ReadOnlySpan<char> comment) => Console.WriteLine($"XML Comment `{comment.ToString()}`");
+    public virtual void OnComment(ReadOnlySpan<char> comment, int line, int column) =>
+        Console.WriteLine($"XML Comment `{comment.ToString()}`, {line}:{column}");
 
-    public virtual void OnText(ReadOnlySpan<char> text) => Console.WriteLine($"XML Content {text.ToString()}");
+    public virtual void OnText(ReadOnlySpan<char> text, int line, int column) =>
+        Console.WriteLine($"XML Content {text.ToString()}, {line}:{column}");
 
-    public virtual void OnError(ReadOnlySpan<char> message) => Console.Error.WriteLine($"XML Error: {message.ToString()}");
+    public virtual void OnError(string message, int line, int column) => Console.Error.WriteLine($"XML Error: {message} {line}:{column}");
 }

--- a/XmlFormat.SAX/SaxParser.cs
+++ b/XmlFormat.SAX/SaxParser.cs
@@ -73,7 +73,7 @@ public static class SaxParser
                     break;
 
                 case XmlTokenizer.XmlToken.Content:
-                    handler.OnContent(token.Span.ToReadOnlySpan());
+                    handler.OnText(token.Span.ToReadOnlySpan());
                     break;
 
                 default:

--- a/XmlFormat.SAX/SaxParser.cs
+++ b/XmlFormat.SAX/SaxParser.cs
@@ -13,15 +13,11 @@ public static class SaxParser
                 case XmlTokenizer.XmlToken.Declaration:
                     var tempDeclaration = XmlTokenParser.Declaration(token.Span);
                     handler.OnXmlDeclaration(
-                        tempDeclaration.Value.Version == null
-                            ? ReadOnlySpan<char>.Empty
-                            : ((TextSpan)tempDeclaration.Value.Version!).ToReadOnlySpan(),
-                        tempDeclaration.Value.Encoding == null
-                            ? ReadOnlySpan<char>.Empty
-                            : ((TextSpan)tempDeclaration.Value.Encoding!).ToReadOnlySpan(),
-                        tempDeclaration.Value.Standalone == null
-                            ? ReadOnlySpan<char>.Empty
-                            : ((TextSpan)tempDeclaration.Value.Standalone!).ToReadOnlySpan()
+                        tempDeclaration.Value.Version == null ? [] : ((TextSpan)tempDeclaration.Value.Version!).ToReadOnlySpan(),
+                        tempDeclaration.Value.Encoding == null ? [] : ((TextSpan)tempDeclaration.Value.Encoding!).ToReadOnlySpan(),
+                        tempDeclaration.Value.Standalone == null ? [] : ((TextSpan)tempDeclaration.Value.Standalone!).ToReadOnlySpan(),
+                        token.Span.Position.Line,
+                        token.Span.Position.Column
                     );
                     break;
 
@@ -29,55 +25,73 @@ public static class SaxParser
                     var tempPI = XmlTokenParser.ProcessingInstruction(token.Span);
                     handler.OnProcessingInstruction(
                         tempPI.Value.Identifier.ToReadOnlySpan(),
-                        tempPI.Value.Contents == null ? ReadOnlySpan<char>.Empty : ((TextSpan)tempPI.Value.Contents!).ToReadOnlySpan()
+                        tempPI.Value.Contents == null ? [] : ((TextSpan)tempPI.Value.Contents!).ToReadOnlySpan(),
+                        token.Span.Position.Line,
+                        token.Span.Position.Column
                     );
                     break;
 
                 case XmlTokenizer.XmlToken.Comment:
                     var tempComment = XmlTokenParser.TrimComment(token.Span);
-                    handler.OnComment(tempComment.Value.ToReadOnlySpan());
+                    handler.OnComment(tempComment.Value.ToReadOnlySpan(), token.Span.Position.Line, token.Span.Position.Column);
                     break;
 
                 case XmlTokenizer.XmlToken.CData:
                     var tempCData = XmlTokenParser.TrimCData(token.Span);
-                    handler.OnCData(tempCData.Value.ToReadOnlySpan());
+                    handler.OnCData(tempCData.Value.ToReadOnlySpan(), token.Span.Position.Line, token.Span.Position.Column);
                     break;
 
                 case XmlTokenizer.XmlToken.ElementStart:
                     var tempElementStart = XmlTokenParser.ElementStart(token.Span);
-                    handler.OnElementStart(tempElementStart.Value.Identifier.ToReadOnlySpan());
+                    handler.OnElementStart(
+                        tempElementStart.Value.Identifier.ToReadOnlySpan(),
+                        token.Span.Position.Line,
+                        token.Span.Position.Column
+                    );
                     foreach (var attribute in tempElementStart.Value.Attributes)
                     {
                         handler.OnAttribute(
                             attribute.Name.ToReadOnlySpan(),
-                            attribute.Value == null ? ReadOnlySpan<char>.Empty : ((TextSpan)attribute.Value!).ToReadOnlySpan()
+                            attribute.Value == null ? [] : ((TextSpan)attribute.Value!).ToReadOnlySpan(),
+                            attribute.Name.Position.Line,
+                            attribute.Name.Position.Column,
+                            attribute.Value == null ? -1 : ((TextSpan)attribute.Value!).Position.Line,
+                            attribute.Value == null ? -1 : ((TextSpan)attribute.Value!).Position.Column
                         );
                     }
                     break;
 
                 case XmlTokenizer.XmlToken.ElementEmpty:
                     var tempElementEmpty = XmlTokenParser.ElementEmpty(token.Span);
-                    handler.OnElementEmpty(tempElementEmpty.Value.Identifier.ToReadOnlySpan());
+                    handler.OnElementEmpty(
+                        tempElementEmpty.Value.Identifier.ToReadOnlySpan(),
+                        token.Span.Position.Line,
+                        token.Span.Position.Column
+                    );
                     foreach (var attribute in tempElementEmpty.Value.Attributes)
                     {
                         handler.OnAttribute(
                             attribute.Name.ToReadOnlySpan(),
-                            attribute.Value == null ? ReadOnlySpan<char>.Empty : ((TextSpan)attribute.Value!).ToReadOnlySpan()
+                            attribute.Value == null ? [] : ((TextSpan)attribute.Value!).ToReadOnlySpan(),
+                            attribute.Name.Position.Line,
+                            attribute.Name.Position.Column,
+                            attribute.Value == null ? -1 : ((TextSpan)attribute.Value!).Position.Line,
+                            attribute.Value == null ? -1 : ((TextSpan)attribute.Value!).Position.Column
                         );
                     }
                     break;
 
                 case XmlTokenizer.XmlToken.ElementEnd:
                     var tempElementEnd = XmlTokenParser.ElementEnd(token.Span);
-                    handler.OnElementEnd(tempElementEnd.Value.ToReadOnlySpan());
+                    handler.OnElementEnd(tempElementEnd.Value.ToReadOnlySpan(), token.Span.Position.Line, token.Span.Position.Column);
                     break;
 
                 case XmlTokenizer.XmlToken.Content:
-                    handler.OnText(token.Span.ToReadOnlySpan());
+                    handler.OnText(token.Span.ToReadOnlySpan(), token.Span.Position.Line, token.Span.Position.Column);
                     break;
 
                 default:
-                    handler.OnError(token.Span.ToReadOnlySpan());
+                    handler.OnError(token.ToString(), token.Span.Position.Line, token.Span.Position.Column);
                     break;
             }
         }


### PR DESCRIPTION
- **refactor: rename interface method IXMLEventHandler.OnContent() -> .OnText()**
  

- **refactor: adapt LoggingXMLEventHandler to renamed interface method**
  

- **refactor: adapt DelegateXMLEventHandler to renamed interface method**
  

- **refactor: adapt IXMLEventHandler interface methods to take line and column**
  reason: make interface methods similar to TurboXML.IXmlReadHandler
  

- **refactor: adapt interface method IXMLEventHandler.OnError() to take error as string, along with line and column**
  reason: make interface methods similar to TurboXML.
  

- **refactor: adapt interface method IXMLEventHandler.OnAttribute() to take line and column for both attribute name and value**
  reason: make interface methods similar to TurboXML.
  

- **refactor: adapt LoggingXMLEventHandler to interface method signature changes**
  

- **refactor: adapt DelegateXMLEventHandler to interface method signature changes**
  

- **refactor: adapt SAX.EventHandler.Test unit tests to changed interfaces**
  

- **refactor: pass parsed span position (line, column) from SaxParser to IXMLEventHandler**
  