### PR TITLE
refactor: replace usage of TurboXml.XmlParser with our own XmlFormat.SAX.SaxParser

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,7 +10,6 @@
   <ItemGroup Label="functionality dependencies">
     <PackageVersion Include="Superpower" Version="3.0.0" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
-    <PackageVersion Include="TurboXml" Version="2.0.2" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
   </ItemGroup>
 

--- a/XmlFormat.Lib/FormattingXmlReadHandler.cs
+++ b/XmlFormat.Lib/FormattingXmlReadHandler.cs
@@ -2,7 +2,6 @@ using System;
 using System.CodeDom.Compiler;
 using System.Linq;
 using System.Text;
-using TurboXml;
 
 namespace XmlFormat;
 
@@ -95,16 +94,16 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         textWriter.WriteLine("");
     }
 
-    public override void OnBeginTag(ReadOnlySpan<char> name, int line, int column)
+    public override void OnElementStart(ReadOnlySpan<char> name, int line, int column)
     {
         if (requireClosingPreviousElementTag)
-            OnBeginTagClose();
+            OnElementStartClose(inline: false);
 
         requireClosingPreviousElementTag = true;
         textWriter.Write($"<{name}");
     }
 
-    public virtual void OnBeginTagClose()
+    public virtual void OnElementStartClose(bool inline = false)
     {
         if (currentAttributes != null)
         {
@@ -131,24 +130,27 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
 
         if (requireClosingPreviousElementTag)
         {
-            textWriter.WriteLine(">");
+            if (inline)
+                textWriter.Write(">");
+            else
+                textWriter.WriteLine(">");
             requireClosingPreviousElementTag = false;
         }
 
         textWriter.Indent++;
     }
 
-    public override void OnEndTagEmpty()
+    public override void OnElementEmpty(ReadOnlySpan<char> name, int line, int column)
     {
         requireClosingPreviousElementTag = false;
         bool multiLineAttributes = currentAttributes?.SingleLineLength() > Options.LineLength;
-        OnBeginTagClose();
+        OnElementStartClose();
         textWriter.Indent--;
 
         textWriter.WriteLine($"{(multiLineAttributes ? "" : " ")}/>");
     }
 
-    public override void OnEndTag(ReadOnlySpan<char> name, int line, int column)
+    public override void OnElementEnd(ReadOnlySpan<char> name, int line, int column)
     {
         textWriter.Indent--;
         textWriter.WriteLine($"</{name}>");
@@ -169,20 +171,29 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
 
     public override void OnText(ReadOnlySpan<char> text, int line, int column)
     {
+        bool inlineContents = text.ToString().Split('\n').Length <= 2; //< 1 empty line = 2x \n, 2 empty lines = 3x \n
+        bool addExtraLine = text.ToString().Split('\n').Length > 2; //< 1 empty line = 2x \n, 2 empty lines = 3x \n
+
         if (requireClosingPreviousElementTag)
-            OnBeginTagClose();
+            OnElementStartClose(inlineContents);
 
         var trimText = text.ToString().Trim();
         if (!string.IsNullOrEmpty(trimText))
-            writer.WriteLine(trimText);
-        if (text.ToString().Split('\n').Length > 2) //< 1 empty line = 2x \n, 2 empty lines = 3x \n
+        {
+            if (inlineContents)
+                textWriter.Write(trimText);
+            else
+                textWriter.WriteLine(trimText);
+        }
+
+        if (addExtraLine)
             writer.WriteLine("");
     }
 
     public override void OnComment(ReadOnlySpan<char> comment, int line, int column)
     {
         if (requireClosingPreviousElementTag)
-            OnBeginTagClose();
+            OnElementStartClose();
 
         if (comment.Length < Options.LineLength)
         {
@@ -201,7 +212,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
     public override void OnCData(ReadOnlySpan<char> cdata, int line, int column)
     {
         if (requireClosingPreviousElementTag)
-            OnBeginTagClose();
+            OnElementStartClose();
 
         textWriter.Indent++;
         textWriter.Write("<![CDATA[");
@@ -215,7 +226,6 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
 
 internal static class IEnumerableOfAttributesExtensions
 {
-    public static int SingleLineLength(
-        this IEnumerable<FormattingXmlReadHandler.Attribute> attributes
-    ) => attributes.Sum(k => k.Name.Length + k.Value.Length + 4); //< ' =""' are the 4 extra chars
+    public static int SingleLineLength(this IEnumerable<FormattingXmlReadHandler.Attribute> attributes) =>
+        attributes.Sum(k => k.Name.Length + k.Value.Length + 4); //< ' =""' are the 4 extra chars
 }

--- a/XmlFormat.Lib/XmlFormat.Lib.csproj
+++ b/XmlFormat.Lib/XmlFormat.Lib.csproj
@@ -17,6 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\XmlFormat.SAX\XmlFormat.SAX.csproj" />
   </ItemGroup>
 
 </Project>

--- a/XmlFormat.Lib/XmlFormat.Lib.csproj
+++ b/XmlFormat.Lib/XmlFormat.Lib.csproj
@@ -17,7 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TurboXml" />
   </ItemGroup>
 
 </Project>

--- a/XmlFormat.Lib/XmlFormat.cs
+++ b/XmlFormat.Lib/XmlFormat.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Text;
-using TurboXml;
+using XmlFormat.SAX;
 
 namespace XmlFormat;
 
@@ -8,12 +8,10 @@ public static class XmlFormat
 {
     public static void Format(Stream inputStream, Stream outputStream, FormattingOptions options)
     {
-        using var handler = new FormattingXmlReadHandler(
-            stream: outputStream,
-            encoding: Encoding.UTF8,
-            options: options
-        );
-        XmlParser.Parse(inputStream, handler);
+        using StreamReader reader = new(inputStream);
+        using var handler = new FormattingXmlReadHandler(stream: outputStream, encoding: Encoding.UTF8, options: options);
+
+        SaxParser.Parse(reader.ReadToEnd(), handler);
     }
 
     public static string Format(string xml, FormattingOptions options)

--- a/XmlFormat.Lib/XmlReadHandlerBase.cs
+++ b/XmlFormat.Lib/XmlReadHandlerBase.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Text;
-using TurboXml;
+using XmlFormat.SAX;
 
 namespace XmlFormat;
 
-public class XmlReadHandlerBase : IXmlReadHandler, IDisposable
+public class XmlReadHandlerBase : IXMLEventHandler, IDisposable
 {
     protected readonly StreamWriter writer;
 
@@ -39,15 +39,21 @@ public class XmlReadHandlerBase : IXmlReadHandler, IDisposable
         ReadOnlySpan<char> standalone,
         int line,
         int column
-    ) => writer.WriteLine($"Xml({line + 1}:{column + 1}): {version} {encoding} {standalone}");
+    ) => writer.WriteLine($"Xml({line}:{column}): {version} {encoding} {standalone}");
 
-    public virtual void OnBeginTag(ReadOnlySpan<char> name, int line, int column) =>
-        writer.WriteLine($"BeginTag({line + 1}:{column + 1}): {name}");
+    public virtual void OnProcessingInstruction(ReadOnlySpan<char> identifier, ReadOnlySpan<char> contents, int line, int column) =>
+        writer.WriteLine($"PI({line}:{column}): {identifier} {contents}");
 
-    public virtual void OnEndTagEmpty() => writer.WriteLine($"EndTagEmpty");
+    public virtual void OnElementStart(ReadOnlySpan<char> name, int line, int column) =>
+        writer.WriteLine($"ElementStart({line}:{column}): {name}");
 
-    public virtual void OnEndTag(ReadOnlySpan<char> name, int line, int column) =>
-        writer.WriteLine($"EndTag({line + 1}:{column + 1}): {name}");
+    public virtual void OnElementEmpty(ReadOnlySpan<char> name, int line, int column) =>
+        writer.WriteLine($"ElementEmpty({line}:{column}): {name}");
+
+    //public virtual void OnEndTagEmpty() => writer.WriteLine($"EndTagEmpty");
+
+    public virtual void OnElementEnd(ReadOnlySpan<char> name, int line, int column) =>
+        writer.WriteLine($"ElementEnd({line}:{column}): {name}");
 
     public virtual void OnAttribute(
         ReadOnlySpan<char> name,
@@ -56,22 +62,16 @@ public class XmlReadHandlerBase : IXmlReadHandler, IDisposable
         int nameColumn,
         int valueLine,
         int valueColumn
-    ) =>
-        writer.WriteLine(
-            $"Attribute({nameLine + 1}:{nameColumn + 1})-({valueLine + 1}:{valueColumn + 1}): {name}=\"{value}\""
-        );
+    ) => writer.WriteLine($"Attribute({nameLine}:{nameColumn})-({valueLine}:{valueColumn}): {name}=\"{value}\"");
 
-    public virtual void OnText(ReadOnlySpan<char> text, int line, int column) =>
-        writer.WriteLine($"Content({line + 1}:{column + 1}): {text}");
+    public virtual void OnText(ReadOnlySpan<char> text, int line, int column) => writer.WriteLine($"Content({line}:{column}): {text}");
 
     public virtual void OnComment(ReadOnlySpan<char> comment, int line, int column) =>
-        writer.WriteLine($"Comment({line + 1}:{column + 1}): {comment}");
+        writer.WriteLine($"Comment({line}:{column}): {comment}");
 
-    public virtual void OnCData(ReadOnlySpan<char> cdata, int line, int column) =>
-        writer.WriteLine($"CDATA({line + 1}:{column + 1}): {cdata}");
+    public virtual void OnCData(ReadOnlySpan<char> cdata, int line, int column) => writer.WriteLine($"CDATA({line}:{column}): {cdata}");
 
-    public virtual void OnError(string message, int line, int column) =>
-        Console.Error.WriteLine($"ERROR({line + 1}:{column + 1}): {message}");
+    public virtual void OnError(string message, int line, int column) => Console.Error.WriteLine($"ERROR({line}:{column}): {message}");
 
     #endregion
 }

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -25,7 +25,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
     <PackageReference Include="CommandLineParser" />
-    <PackageReference Include="TurboXml" />
   </ItemGroup>
 
   <ItemGroup Label="project references">


### PR DESCRIPTION
- **build: remove package reference to TurboXML**
- **build: reference XmlFormat.SAX project**
- **refactor: adapt XmlReadHandlerBase to inherit from XmlFormat.SAX.IXMLEventHandler**
- **refactor: adapt FormattingXmlReadHandler to changed inheritance in base class**
- **refactor: XmlFormat.Format() to use XmlFormat.SAX.SaxParser**
