### PR TITLE
fix: correctly tokenize multiple adjacent tags

### DIFF
--- a/Tests/SAX.Tokenizer.Test/NegativeTokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/NegativeTokenizerTests.cs
@@ -29,18 +29,10 @@ public class NegativeTokenizerTest
         Assert.False(TestHelper.Tokenize("<!--comment --", [XmlTokenizer.XmlToken.Comment]));
         Assert.False(TestHelper.Tokenize("<!-- comment>", [XmlTokenizer.XmlToken.Comment]));
         Assert.False(TestHelper.Tokenize("<!-- comment ", [XmlTokenizer.XmlToken.Comment]));
-        Assert.False(
-            TestHelper.Tokenize("<!--\ncomment\nmore comment\n", [XmlTokenizer.XmlToken.Comment])
-        );
-        Assert.False(
-            TestHelper.Tokenize("<!--\ncomment\nmore comment\n ", [XmlTokenizer.XmlToken.Comment])
-        );
-        Assert.False(
-            TestHelper.Tokenize("<!-- \ncomment\nmore comment\n->", [XmlTokenizer.XmlToken.Comment])
-        );
-        Assert.False(
-            TestHelper.Tokenize("<!-- \ncomment\nmore comment\n >", [XmlTokenizer.XmlToken.Comment])
-        );
+        Assert.False(TestHelper.Tokenize("<!--\ncomment\nmore comment\n", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.Tokenize("<!--\ncomment\nmore comment\n ", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.Tokenize("<!-- \ncomment\nmore comment\n->", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.Tokenize("<!-- \ncomment\nmore comment\n >", [XmlTokenizer.XmlToken.Comment]));
     }
 
     [Fact]
@@ -53,18 +45,10 @@ public class NegativeTokenizerTest
         Assert.False(TestHelper.Tokenize("<![CDATA[foobar >", [XmlTokenizer.XmlToken.CData]));
         Assert.False(TestHelper.Tokenize("<![CDATA[ foobar]]", [XmlTokenizer.XmlToken.CData]));
         Assert.False(TestHelper.Tokenize("<![CDATA[ foobar ", [XmlTokenizer.XmlToken.CData]));
-        Assert.False(
-            TestHelper.Tokenize("<![CDATA[\nfoobar\nhoge\n]>", [XmlTokenizer.XmlToken.CData])
-        );
-        Assert.False(
-            TestHelper.Tokenize("<![CDATA[\nfoobar\nhoge\n ]]", [XmlTokenizer.XmlToken.CData])
-        );
-        Assert.False(
-            TestHelper.Tokenize("<![CDATA[ \nfoobar\nhoge\n] >", [XmlTokenizer.XmlToken.CData])
-        );
-        Assert.False(
-            TestHelper.Tokenize("<![CDATA[ \nfoobar\nhoge\n ", [XmlTokenizer.XmlToken.CData])
-        );
+        Assert.False(TestHelper.Tokenize("<![CDATA[\nfoobar\nhoge\n]>", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.Tokenize("<![CDATA[\nfoobar\nhoge\n ]]", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.Tokenize("<![CDATA[ \nfoobar\nhoge\n] >", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.Tokenize("<![CDATA[ \nfoobar\nhoge\n ", [XmlTokenizer.XmlToken.CData]));
     }
 
     [Fact]

--- a/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
@@ -116,6 +116,10 @@ public class TokenizerTest
         "<Window\n  xmlns=\"https://github.com/avaloniaui\"\n  xmlns:d=\"http://schemas.microsoft.com/expression/blend/2008\"\n  xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\"\n  xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"\n  xmlns:vm=\"using:GitRise\"\n  d:DesignHeight=\"450\"\n  d:DesignWidth=\"800\"\n  mc:Ignorable=\"d\"\n  x:Class=\"GitRise.MainWindow\"\n  x:DataType=\"vm:MainWindowViewModel\"\n  Icon=\"avares://GitRise/Resources/GitRise.ico\"\n  Title=\"GitRise\"\n>",
         XmlTokenizer.XmlToken.ElementStart
     )]
+    [InlineData(
+        "<Window\n  xmlns=\"https://github.com/avaloniaui\"\n  xmlns:d=\"http://schemas.microsoft.com/expression/blend/2008\"\n  xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\"\n  xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"\n  xmlns:vm=\"using:GitRise\"\n  d:DesignHeight=\"450\"\n  d:DesignWidth=\"800\"\n  mc:Ignorable=\"d\"\n  x:Class=\"GitRise.MainWindow\"\n  x:DataType=\"vm:MainWindowViewModel\"\n  Icon=\"avares://GitRise/Resources/GitRise.ico\"\n  Title=\"GitRise\"\n/>",
+        XmlTokenizer.XmlToken.ElementEmpty
+    )]
     public void TestElementWithAttributes(string input, XmlTokenizer.XmlToken expectedToken)
     {
         Assert.True(TestHelper.Tokenize(input, [expectedToken]));

--- a/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
@@ -166,4 +166,17 @@ public class TokenizerTest
     {
         Assert.True(TestHelper.Tokenize(input, [expectedToken1, expectedToken2, expectedToken3]));
     }
+
+    [Theory]
+    [InlineData(
+        "    <!-- main window -->\n<Window\n  xmlns=\"https://github.com/avaloniaui\"\n  xmlns:d=\"http://schemas.microsoft.com/expression/blend/2008\"\n  xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\"\n  xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"\n  xmlns:vm=\"using:GitRise\"\n  d:DesignHeight=\"450\"\n  d:DesignWidth=\"800\"\n  mc:Ignorable=\"d\"\n  x:Class=\"GitRise.MainWindow\"\n  x:DataType=\"vm:MainWindowViewModel\"\n  Icon=\"avares://GitRise/Resources/GitRise.ico\"\n  Title=\"GitRise\"\n>\n  <!-- ABC -->\n  <StackPanel>",
+        XmlTokenizer.XmlToken.Comment,
+        XmlTokenizer.XmlToken.ElementStart,
+        XmlTokenizer.XmlToken.Comment,
+        XmlTokenizer.XmlToken.ElementStart
+    )]
+    public void Test4Elements(string input, XmlTokenizer.XmlToken expectedToken1, XmlTokenizer.XmlToken expectedToken2, XmlTokenizer.XmlToken expectedToken3, XmlTokenizer.XmlToken expectedToken4)
+    {
+        Assert.True(TestHelper.Tokenize(input, [expectedToken1, expectedToken2, expectedToken3, expectedToken4]));
+    }
 }

--- a/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
@@ -131,4 +131,22 @@ public class TokenizerTest
     {
         Assert.True(TestHelper.Tokenize(input, [expectedToken]));
     }
+
+    [Theory]
+    [InlineData("<aaa/><bbb/>", XmlTokenizer.XmlToken.ElementEmpty, XmlTokenizer.XmlToken.ElementEmpty)]
+    [InlineData("<aaa><bbb/>", XmlTokenizer.XmlToken.ElementStart, XmlTokenizer.XmlToken.ElementEmpty)]
+    [InlineData("<aaa><bbb>", XmlTokenizer.XmlToken.ElementStart, XmlTokenizer.XmlToken.ElementStart)]
+    [InlineData("<aaa></aaa>", XmlTokenizer.XmlToken.ElementStart, XmlTokenizer.XmlToken.ElementEnd)]
+    [InlineData("<aaa>Hello World", XmlTokenizer.XmlToken.ElementStart, XmlTokenizer.XmlToken.Content)]
+    [InlineData("<aaa><!-- Hello World -->", XmlTokenizer.XmlToken.ElementStart, XmlTokenizer.XmlToken.Comment)]
+    [InlineData("<aaa><![CDATA[ Hello World ]]>", XmlTokenizer.XmlToken.ElementStart, XmlTokenizer.XmlToken.CData)]
+    [InlineData(
+        "    <!-- main window -->\n<Window\n  xmlns=\"https://github.com/avaloniaui\"\n  xmlns:d=\"http://schemas.microsoft.com/expression/blend/2008\"\n  xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\"\n  xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"\n  xmlns:vm=\"using:GitRise\"\n  d:DesignHeight=\"450\"\n  d:DesignWidth=\"800\"\n  mc:Ignorable=\"d\"\n  x:Class=\"GitRise.MainWindow\"\n  x:DataType=\"vm:MainWindowViewModel\"\n  Icon=\"avares://GitRise/Resources/GitRise.ico\"\n  Title=\"GitRise\"\n>\n  ",
+        XmlTokenizer.XmlToken.Comment,
+        XmlTokenizer.XmlToken.ElementStart
+    )]
+    public void Test2Elements(string input, XmlTokenizer.XmlToken expectedToken1, XmlTokenizer.XmlToken expectedToken2)
+    {
+        Assert.True(TestHelper.Tokenize(input, [expectedToken1, expectedToken2]));
+    }
 }

--- a/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
@@ -112,6 +112,10 @@ public class TokenizerTest
     [InlineData("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone \n>", XmlTokenizer.XmlToken.ElementStart)]
     [InlineData("<element foobar=\"hogehoge\"   xyz=\"abc\">", XmlTokenizer.XmlToken.ElementStart)]
     [InlineData("<element foobar=\"hogehoge\"   xyz=\"abc\" >", XmlTokenizer.XmlToken.ElementStart)]
+    [InlineData(
+        "<Window\n  xmlns=\"https://github.com/avaloniaui\"\n  xmlns:d=\"http://schemas.microsoft.com/expression/blend/2008\"\n  xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\"\n  xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"\n  xmlns:vm=\"using:GitRise\"\n  d:DesignHeight=\"450\"\n  d:DesignWidth=\"800\"\n  mc:Ignorable=\"d\"\n  x:Class=\"GitRise.MainWindow\"\n  x:DataType=\"vm:MainWindowViewModel\"\n  Icon=\"avares://GitRise/Resources/GitRise.ico\"\n  Title=\"GitRise\"\n>",
+        XmlTokenizer.XmlToken.ElementStart
+    )]
     public void TestElementWithAttributes(string input, XmlTokenizer.XmlToken expectedToken)
     {
         Assert.True(TestHelper.Tokenize(input, [expectedToken]));

--- a/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
@@ -149,4 +149,21 @@ public class TokenizerTest
     {
         Assert.True(TestHelper.Tokenize(input, [expectedToken1, expectedToken2]));
     }
+
+    [Theory]
+    [InlineData("<aaa/><bbb/><ccc/>", XmlTokenizer.XmlToken.ElementEmpty, XmlTokenizer.XmlToken.ElementEmpty, XmlTokenizer.XmlToken.ElementEmpty)]
+    [InlineData("<aaa><bbb/></aaa>", XmlTokenizer.XmlToken.ElementStart, XmlTokenizer.XmlToken.ElementEmpty, XmlTokenizer.XmlToken.ElementEnd)]
+    [InlineData("<aaa>hello world</aaa>", XmlTokenizer.XmlToken.ElementStart, XmlTokenizer.XmlToken.Content, XmlTokenizer.XmlToken.ElementEnd)]
+    [InlineData("<aaa><!-- hello world --></aaa>", XmlTokenizer.XmlToken.ElementStart, XmlTokenizer.XmlToken.Comment, XmlTokenizer.XmlToken.ElementEnd)]
+    [InlineData("<aaa><![CDATA[ hello world ]]></aaa>", XmlTokenizer.XmlToken.ElementStart, XmlTokenizer.XmlToken.CData, XmlTokenizer.XmlToken.ElementEnd)]
+    [InlineData(
+        "    <!-- main window -->\n<Window\n  xmlns=\"https://github.com/avaloniaui\"\n  xmlns:d=\"http://schemas.microsoft.com/expression/blend/2008\"\n  xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\"\n  xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"\n  xmlns:vm=\"using:GitRise\"\n  d:DesignHeight=\"450\"\n  d:DesignWidth=\"800\"\n  mc:Ignorable=\"d\"\n  x:Class=\"GitRise.MainWindow\"\n  x:DataType=\"vm:MainWindowViewModel\"\n  Icon=\"avares://GitRise/Resources/GitRise.ico\"\n  Title=\"GitRise\"\n>\n  <!-- ABC -->\n  ",
+        XmlTokenizer.XmlToken.Comment,
+        XmlTokenizer.XmlToken.ElementStart,
+        XmlTokenizer.XmlToken.Comment
+    )]
+    public void Test3Elements(string input, XmlTokenizer.XmlToken expectedToken1, XmlTokenizer.XmlToken expectedToken2, XmlTokenizer.XmlToken expectedToken3)
+    {
+        Assert.True(TestHelper.Tokenize(input, [expectedToken1, expectedToken2, expectedToken3]));
+    }
 }

--- a/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
@@ -96,12 +96,8 @@ public class TokenizerTest
     [InlineData("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n />", XmlTokenizer.XmlToken.ElementEmpty)]
     [InlineData("<element foobar=\"hogehoge\"   xyz=\"abc\"/>", XmlTokenizer.XmlToken.ElementEmpty)]
     [InlineData("<element foobar=\"hogehoge\"   xyz=\"abc\" />", XmlTokenizer.XmlToken.ElementEmpty)]
-    [InlineData("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n/>", XmlTokenizer.XmlToken.ElementEmpty)]
-    [InlineData("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n />", XmlTokenizer.XmlToken.ElementEmpty)]
     [InlineData("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone/>", XmlTokenizer.XmlToken.ElementEmpty)]
     [InlineData("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone />", XmlTokenizer.XmlToken.ElementEmpty)]
-    [InlineData("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n/>", XmlTokenizer.XmlToken.ElementEmpty)]
-    [InlineData("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n />", XmlTokenizer.XmlToken.ElementEmpty)]
     [InlineData("<element foobar=\"hogehoge\">", XmlTokenizer.XmlToken.ElementStart)]
     [InlineData("<element foobar=\"hogehoge\" >", XmlTokenizer.XmlToken.ElementStart)]
     [InlineData("<element foobar=\"{hogehoge}\">", XmlTokenizer.XmlToken.ElementStart)]
@@ -116,12 +112,6 @@ public class TokenizerTest
     [InlineData("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone \n>", XmlTokenizer.XmlToken.ElementStart)]
     [InlineData("<element foobar=\"hogehoge\"   xyz=\"abc\">", XmlTokenizer.XmlToken.ElementStart)]
     [InlineData("<element foobar=\"hogehoge\"   xyz=\"abc\" >", XmlTokenizer.XmlToken.ElementStart)]
-    [InlineData("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n>", XmlTokenizer.XmlToken.ElementStart)]
-    [InlineData("<element foobar=\"{hogehoge}\" xyz=\"abc\" \n>", XmlTokenizer.XmlToken.ElementStart)]
-    [InlineData("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone>", XmlTokenizer.XmlToken.ElementStart)]
-    [InlineData("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone >", XmlTokenizer.XmlToken.ElementStart)]
-    [InlineData("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n>", XmlTokenizer.XmlToken.ElementStart)]
-    [InlineData("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone \n>", XmlTokenizer.XmlToken.ElementStart)]
     public void TestElementWithAttributes(string input, XmlTokenizer.XmlToken expectedToken)
     {
         Assert.True(TestHelper.Tokenize(input, [expectedToken]));

--- a/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
@@ -193,4 +193,19 @@ public class TokenizerTest
     {
         Assert.True(TestHelper.Tokenize(input, [expectedToken1, expectedToken2, expectedToken3, expectedToken4, expectedToken5]));
     }
+
+    [Theory]
+    [InlineData(
+        "    <!-- main window -->\n<Window\n  xmlns=\"https://github.com/avaloniaui\"\n  xmlns:d=\"http://schemas.microsoft.com/expression/blend/2008\"\n  xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\"\n  xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"\n  xmlns:vm=\"using:GitRise\"\n  d:DesignHeight=\"450\"\n  d:DesignWidth=\"800\"\n  mc:Ignorable=\"d\"\n  x:Class=\"GitRise.MainWindow\"\n  x:DataType=\"vm:MainWindowViewModel\"\n  Icon=\"avares://GitRise/Resources/GitRise.ico\"\n  Title=\"GitRise\"\n>\n  <!-- ABC -->\n  <StackPanel><DataGrid AutoGenerateColumns=\"True\" ItemsSource=\"{CompiledBinding Commits}\" />\n  </StackPanel>\n",
+        XmlTokenizer.XmlToken.Comment,
+        XmlTokenizer.XmlToken.ElementStart,
+        XmlTokenizer.XmlToken.Comment,
+        XmlTokenizer.XmlToken.ElementStart,
+        XmlTokenizer.XmlToken.ElementEmpty,
+        XmlTokenizer.XmlToken.ElementEnd
+    )]
+    public void Test6Elements(string input, XmlTokenizer.XmlToken expectedToken1, XmlTokenizer.XmlToken expectedToken2, XmlTokenizer.XmlToken expectedToken3, XmlTokenizer.XmlToken expectedToken4, XmlTokenizer.XmlToken expectedToken5, XmlTokenizer.XmlToken expectedToken6)
+    {
+        Assert.True(TestHelper.Tokenize(input, [expectedToken1, expectedToken2, expectedToken3, expectedToken4, expectedToken5, expectedToken6]));
+    }
 }

--- a/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
@@ -179,4 +179,18 @@ public class TokenizerTest
     {
         Assert.True(TestHelper.Tokenize(input, [expectedToken1, expectedToken2, expectedToken3, expectedToken4]));
     }
+
+    [Theory]
+    [InlineData(
+        "    <!-- main window -->\n<Window\n  xmlns=\"https://github.com/avaloniaui\"\n  xmlns:d=\"http://schemas.microsoft.com/expression/blend/2008\"\n  xmlns:x=\"http://schemas.microsoft.com/winfx/2006/xaml\"\n  xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\"\n  xmlns:vm=\"using:GitRise\"\n  d:DesignHeight=\"450\"\n  d:DesignWidth=\"800\"\n  mc:Ignorable=\"d\"\n  x:Class=\"GitRise.MainWindow\"\n  x:DataType=\"vm:MainWindowViewModel\"\n  Icon=\"avares://GitRise/Resources/GitRise.ico\"\n  Title=\"GitRise\"\n>\n  <!-- ABC -->\n  <StackPanel><DataGrid AutoGenerateColumns=\"True\" ItemsSource=\"{CompiledBinding Commits}\" />\n  ",
+        XmlTokenizer.XmlToken.Comment,
+        XmlTokenizer.XmlToken.ElementStart,
+        XmlTokenizer.XmlToken.Comment,
+        XmlTokenizer.XmlToken.ElementStart,
+        XmlTokenizer.XmlToken.ElementEmpty
+    )]
+    public void Test5Elements(string input, XmlTokenizer.XmlToken expectedToken1, XmlTokenizer.XmlToken expectedToken2, XmlTokenizer.XmlToken expectedToken3, XmlTokenizer.XmlToken expectedToken4, XmlTokenizer.XmlToken expectedToken5)
+    {
+        Assert.True(TestHelper.Tokenize(input, [expectedToken1, expectedToken2, expectedToken3, expectedToken4, expectedToken5]));
+    }
 }

--- a/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/TokenizerTests.cs
@@ -30,6 +30,8 @@ public class TokenizerTest
     [InlineData("<!--\ncomment\nmore comment\n -->", XmlTokenizer.XmlToken.Comment)]
     [InlineData("<!-- \ncomment\nmore comment\n-->", XmlTokenizer.XmlToken.Comment)]
     [InlineData("<!-- \ncomment\nmore comment\n -->", XmlTokenizer.XmlToken.Comment)]
+    [InlineData("<!-- <comment>\n<more comment>\n -->", XmlTokenizer.XmlToken.Comment)]
+    [InlineData("<!-- <comment/>\n<more comment/>\n -->", XmlTokenizer.XmlToken.Comment)]
     public void TestComment(string input, XmlTokenizer.XmlToken expectedToken)
     {
         Assert.True(TestHelper.Tokenize(input, [expectedToken]));

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -65,6 +65,12 @@ public static class XmlTokenizer
     }
 
     /// <summary>
+    /// sub parser for XML characters
+    /// </summary>
+    public static TextParser<Unit> XmlChar { get; } =
+        Character.LetterOrDigit.Or(Character.EqualTo(':')).Or(Character.EqualTo('_')).Or(Character.EqualTo('-')).Value(Unit.Value);
+
+    /// <summary>
     /// token parser for XML Declaration
     /// </summary>
     static TextParser<Unit> XmlDeclaration { get; } =

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -98,7 +98,7 @@ public static class XmlTokenizer
     /// </summary>
     static TextParser<Unit> XmlProcessingInstruction { get; } =
         from open in Span.EqualTo("<?").Try()
-        from identifier in Character.LetterOrDigit.AtLeastOnce().Value(Unit.Value).Try()
+        from identifier in XmlChars.Value(Unit.Value).Try()
         from rest in Span.Except("?>").Many().Value(Unit.Value).Try()
         from close in Span.EqualTo("?>").Try()
         select Unit.Value;

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -134,9 +134,9 @@ public static class XmlTokenizer
     /// </summary>
     static TextParser<Unit> XmlElementStart { get; } =
         from open in Character.EqualTo('<').Try()
-        from identifier in Character.LetterOrDigit.AtLeastOnce().Value(Unit.Value).Try()
-        from rest in Character.Except('>').Many().Value(Unit.Value).Try()
-        from close in Character.EqualTo('>').Try()
+        from identifier in XmlChars.Value(Unit.Value).Try()
+        from attributes in Span.WhiteSpace.IgnoreThen(XmlAttribute).Many().Try()
+        from close in Character.WhiteSpace.Many().IgnoreThen(Character.EqualTo('>')).Try()
         select Unit.Value;
 
     /// <summary>

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -154,9 +154,8 @@ public static class XmlTokenizer
     /// </summary>
     static TextParser<Unit> XmlElementEnd { get; } =
         from open in Span.EqualTo("</").Try()
-        from identifier in Character.LetterOrDigit.AtLeastOnce().Value(Unit.Value).Try()
-        from rest in Character.Except('>').Many().Value(Unit.Value).Try()
-        from close in Character.EqualTo('>')
+        from identifier in XmlChars.Value(Unit.Value).Try()
+        from close in Character.WhiteSpace.Many().IgnoreThen(Character.EqualTo('>')).Try()
         select Unit.Value;
 
     /// <summary>

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -122,6 +122,14 @@ public static class XmlTokenizer
         select Unit.Value;
 
     /// <summary>
+    /// sub token parser for attribute="value"
+    /// </summary>
+    static TextParser<Unit> XmlAttribute { get; } =
+        from identifier in XmlChars.Value(Unit.Value).Try()
+        from value in Span.EqualTo("=").IgnoreThen(QuotedStringWithQuotes).Optional()
+        select Unit.Value;
+
+    /// <summary>
     /// token parser for opening <element>
     /// </summary>
     static TextParser<Unit> XmlElementStart { get; } =

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -71,6 +71,11 @@ public static class XmlTokenizer
         Character.LetterOrDigit.Or(Character.EqualTo(':')).Or(Character.EqualTo('_')).Or(Character.EqualTo('-')).Value(Unit.Value);
 
     /// <summary>
+    /// sub parser for several XML characters
+    /// </summary>
+    public static TextParser<Unit> XmlChars { get; } = XmlChar.AtLeastOnce().Value(Unit.Value);
+
+    /// <summary>
     /// token parser for XML Declaration
     /// </summary>
     static TextParser<Unit> XmlDeclaration { get; } =

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -144,9 +144,9 @@ public static class XmlTokenizer
     /// </summary>
     static TextParser<Unit> XmlElementEmpty { get; } =
         from open in Character.EqualTo('<').Try()
-        from identifier in Character.LetterOrDigit.AtLeastOnce().Value(Unit.Value).Try()
-        from rest in Span.Except("/>").Many().Value(Unit.Value).Try()
-        from close in Character.EqualTo('/').IgnoreThen(Character.EqualTo('>')).Try()
+        from identifier in XmlChars.Value(Unit.Value).Try()
+        from attributes in Span.WhiteSpace.IgnoreThen(XmlAttribute).Many().Try()
+        from close in Character.WhiteSpace.Many().IgnoreThen(Span.EqualTo("/>")).Try()
         select Unit.Value;
 
     /// <summary>

--- a/XmlFormat.SAX/Tokenizer.cs
+++ b/XmlFormat.SAX/Tokenizer.cs
@@ -76,6 +76,15 @@ public static class XmlTokenizer
     public static TextParser<Unit> XmlChars { get; } = XmlChar.AtLeastOnce().Value(Unit.Value);
 
     /// <summary>
+    /// sub parser for several XML characters
+    /// </summary>
+    public static TextParser<Unit> QuotedStringWithQuotes { get; } =
+        from lq in Span.EqualTo("\"")
+        from qt in Span.Except("\"").Optional().Value(Unit.Value)
+        from rq in Span.EqualTo("\"")
+        select Unit.Value;
+
+    /// <summary>
     /// token parser for XML Declaration
     /// </summary>
     static TextParser<Unit> XmlDeclaration { get; } =


### PR DESCRIPTION
- **feat: implement token sub parser for single XML identifier characters**
- **feat: implement token sub parser for XML identifier characters**
- **feat: implement token sub parser for Quoted String (including quotes)**
- **feat: implement token sub parser for XML attributes**
- **refactor: adapt XmlProcessingInstruction parser to use XmlChars parser**
- **refactor: improve XmlElementStart parser**
- **refactor: improve XmlElementEmpty parser**
- **refactor: improve XmlElementEnd parser**
- **feat: add more tokenizer test cases for Comment tokens**
- **refactor: remove duplicate test cases**
- **feat: add complex test case for single ElementStart token**
- **feat: add complex test case for single ElementEmpty token**
- **feat: implement tokenizer unit test cases for 2 elements**
- **feat: implement tokenizer unit test cases for 3 elements**
- **feat: implement tokenizer unit test cases for 4 elements**
- **feat: implement tokenizer unit test cases for 5 elements**
- **feat: implement tokenizer unit test cases for 6 elements**
- **chore: format tokenizer negative unit tests**
