### PR TITLE
fix: ignore whitespace before and after Attributes in Element-specific parsers

### DIFF
--- a/Tests/SAX.TokenParser.Test/ElementAndAttributesParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/ElementAndAttributesParserTest.cs
@@ -180,4 +180,1182 @@ public class ElementAndAttributesParserTest
         Assert.NotEmpty(((TextSpan)attribute.Value!).ToStringValue());
         Assert.Equal(expectedValue, ((TextSpan)attribute.Value!).ToStringValue());
     }
+
+    #region multi attribute tests on real data
+
+    [Theory]
+    [InlineData("<element aaa=\"bbb\" ccc=\"ddd\">", "element", "aaa", "bbb", "ccc", "ddd")]
+    [InlineData("<element attribute=\"hogehoge\" at-tribute=\"hogehoge\">", "element", "attribute", "hogehoge", "at-tribute", "hogehoge")]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+        ",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008"
+    )]
+    public void TestElement2Attributes(string input, string expectedElement, string expectedAttribute0, string expectedValue0, string expectedAttribute1, string expectedValue1)
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(2, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+        ",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml"
+    )]
+    public void TestElement3Attributes(string input, string expectedElement, string expectedAttribute0, string expectedValue0, string expectedAttribute1, string expectedValue1, string expectedAttribute2, string expectedValue2)
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(3, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+        ",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006"
+    )]
+    public void TestElement4Attributes(string input, string expectedElement, string expectedAttribute0, string expectedValue0, string expectedAttribute1, string expectedValue1, string expectedAttribute2, string expectedValue2, string expectedAttribute3, string expectedValue3)
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(4, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+        ",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise"
+    )]
+    public void TestElement5Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4
+    )
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(5, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+        ",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450"
+    )]
+    public void TestElement6Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5
+    )
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(6, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+        ",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800"
+    )]
+    public void TestElement7Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6
+    )
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(7, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+        ",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d"
+    )]
+    public void TestElement8Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7
+    )
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(8, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+        ",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow"
+    )]
+    public void TestElement9Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8
+    )
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(9, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = element.Attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+          x:DataType=""vm:MainWindowViewModel""
+        ",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow",
+        "x:DataType",
+        "vm:MainWindowViewModel"
+    )]
+    public void TestElement10Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8,
+        string expectedAttribute9,
+        string expectedValue9
+    )
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(10, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = element.Attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+
+        var attribute9 = element.Attributes[9];
+        Assert.NotEmpty(attribute9.Name.ToStringValue());
+        Assert.Equal(expectedAttribute9, attribute9.Name.ToStringValue());
+        Assert.NotNull(attribute9.Value);
+        Assert.NotEmpty(((TextSpan)attribute9.Value!).ToStringValue());
+        Assert.Equal(expectedValue9, ((TextSpan)attribute9.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+          x:DataType=""vm:MainWindowViewModel""
+          Icon=""avares://GitRise/Resources/GitRise.ico""
+        ",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow",
+        "x:DataType",
+        "vm:MainWindowViewModel",
+        "Icon",
+        "avares://GitRise/Resources/GitRise.ico"
+    )]
+    public void TestElement11Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8,
+        string expectedAttribute9,
+        string expectedValue9,
+        string expectedAttribute10,
+        string expectedValue10
+    )
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(11, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = element.Attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+
+        var attribute9 = element.Attributes[9];
+        Assert.NotEmpty(attribute9.Name.ToStringValue());
+        Assert.Equal(expectedAttribute9, attribute9.Name.ToStringValue());
+        Assert.NotNull(attribute9.Value);
+        Assert.NotEmpty(((TextSpan)attribute9.Value!).ToStringValue());
+        Assert.Equal(expectedValue9, ((TextSpan)attribute9.Value!).ToStringValue());
+
+        var attribute10 = element.Attributes[10];
+        Assert.NotEmpty(attribute10.Name.ToStringValue());
+        Assert.Equal(expectedAttribute10, attribute10.Name.ToStringValue());
+        Assert.NotNull(attribute10.Value);
+        Assert.NotEmpty(((TextSpan)attribute10.Value!).ToStringValue());
+        Assert.Equal(expectedValue10, ((TextSpan)attribute10.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+          x:DataType=""vm:MainWindowViewModel""
+          Icon=""avares://GitRise/Resources/GitRise.ico""
+          Title=""GitRise""
+        ",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow",
+        "x:DataType",
+        "vm:MainWindowViewModel",
+        "Icon",
+        "avares://GitRise/Resources/GitRise.ico",
+        "Title",
+        "GitRise"
+    )]
+    public void TestElement12Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8,
+        string expectedAttribute9,
+        string expectedValue9,
+        string expectedAttribute10,
+        string expectedValue10,
+        string expectedAttribute11,
+        string expectedValue11
+    )
+    {
+        var result = XmlTokenParser.ElementAndAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(12, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = element.Attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+
+        var attribute9 = element.Attributes[9];
+        Assert.NotEmpty(attribute9.Name.ToStringValue());
+        Assert.Equal(expectedAttribute9, attribute9.Name.ToStringValue());
+        Assert.NotNull(attribute9.Value);
+        Assert.NotEmpty(((TextSpan)attribute9.Value!).ToStringValue());
+        Assert.Equal(expectedValue9, ((TextSpan)attribute9.Value!).ToStringValue());
+
+        var attribute10 = element.Attributes[10];
+        Assert.NotEmpty(attribute10.Name.ToStringValue());
+        Assert.Equal(expectedAttribute10, attribute10.Name.ToStringValue());
+        Assert.NotNull(attribute10.Value);
+        Assert.NotEmpty(((TextSpan)attribute10.Value!).ToStringValue());
+        Assert.Equal(expectedValue10, ((TextSpan)attribute10.Value!).ToStringValue());
+
+        var attribute11 = element.Attributes[11];
+        Assert.NotEmpty(attribute11.Name.ToStringValue());
+        Assert.Equal(expectedAttribute11, attribute11.Name.ToStringValue());
+        Assert.NotNull(attribute11.Value);
+        Assert.NotEmpty(((TextSpan)attribute11.Value!).ToStringValue());
+        Assert.Equal(expectedValue11, ((TextSpan)attribute11.Value!).ToStringValue());
+    }
+
+    #endregion
 }

--- a/Tests/SAX.TokenParser.Test/ElementAttributeParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/ElementAttributeParserTest.cs
@@ -15,7 +15,7 @@ public class ElementAttributeParserTest
     [InlineData("at:tri-bute")]
     [InlineData("at:tri-but_e")]
     [InlineData("attribute0")]
-    public void TestElementAttributeNoValue(string input)
+    public void TestAttributeNoValue(string input)
     {
         var result = XmlTokenParser.ElementAttributeForUnitTestsOnly(new TextSpan(input));
         Console.WriteLine($"parsing: `{input}`\nresult: {result}");
@@ -38,7 +38,7 @@ public class ElementAttributeParserTest
     [InlineData("at:tri-bute=\"\"", "at:tri-bute")]
     [InlineData("at:tri-but_e=\"\"", "at:tri-but_e")]
     [InlineData("attribute0=\"\"", "attribute0")]
-    public void TestElementAttributeEmptyValue(string input, string expected)
+    public void TestAttributeEmptyValue(string input, string expected)
     {
         var result = XmlTokenParser.ElementAttributeForUnitTestsOnly(new TextSpan(input));
         Console.WriteLine($"parsing: `{input}`\nresult: {result}");
@@ -73,7 +73,7 @@ public class ElementAttributeParserTest
     [InlineData("at:tri-bute=\"{hogehoge}\"", "at:tri-bute", "{hogehoge}")]
     [InlineData("at:tri-but_e=\"{hogehoge}\"", "at:tri-but_e", "{hogehoge}")]
     [InlineData("attribute0=\"{hogehoge}\"", "attribute0", "{hogehoge}")]
-    public void TestElementAttribute(string input, string expectedName, string expectedValue)
+    public void TestAttribute(string input, string expectedName, string expectedValue)
     {
         var result = XmlTokenParser.ElementAttributeForUnitTestsOnly(new TextSpan(input));
         Console.WriteLine($"parsing: `{input}`\nresult: {result}");
@@ -89,4 +89,1110 @@ public class ElementAttributeParserTest
         Assert.NotEmpty(attribValue.ToStringValue());
         Assert.Equal(expectedValue, attribValue.ToStringValue());
     }
+
+    #region multi attribute tests on real data
+
+    [Theory]
+    [InlineData("aaa=\"bbb\" ccc=\"ddd\">", "aaa", "bbb", "ccc", "ddd")]
+    [InlineData("attribute=\"hogehoge\" at-tribute=\"hogehoge\">", "attribute", "hogehoge", "at-tribute", "hogehoge")]
+    [InlineData(" aaa=\"bbb\" ccc=\"ddd\">", "aaa", "bbb", "ccc", "ddd")]
+    [InlineData("  attribute=\"hogehoge\" at-tribute=\"hogehoge\">", "attribute", "hogehoge", "at-tribute", "hogehoge")]
+    [InlineData("\tattribute=\"hogehoge\" at-tribute=\"hogehoge\">", "attribute", "hogehoge", "at-tribute", "hogehoge")]
+    [InlineData(
+        @"xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+        ",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008"
+    )]
+    public void Test2Attributes(string input, string expectedAttribute0, string expectedValue0, string expectedAttribute1, string expectedValue1)
+    {
+        var result = XmlTokenParser.ManyElementAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attributes = result.Value;
+        Assert.NotEmpty(attributes);
+        Assert.Equal(2, attributes.Length);
+
+        var attribute0 = attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+        ",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml"
+    )]
+    public void Test3Attributes(string input, string expectedAttribute0, string expectedValue0, string expectedAttribute1, string expectedValue1, string expectedAttribute2, string expectedValue2)
+    {
+        var result = XmlTokenParser.ManyElementAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attributes = result.Value;
+        Assert.NotEmpty(attributes);
+        Assert.Equal(3, attributes.Length);
+
+        var attribute0 = attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+        ",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006"
+    )]
+    public void Test4Attributes(string input, string expectedAttribute0, string expectedValue0, string expectedAttribute1, string expectedValue1, string expectedAttribute2, string expectedValue2, string expectedAttribute3, string expectedValue3)
+    {
+        var result = XmlTokenParser.ManyElementAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attributes = result.Value;
+        Assert.NotEmpty(attributes);
+        Assert.Equal(4, attributes.Length);
+
+        var attribute0 = attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+        ",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise"
+    )]
+    public void Test5Attributes(string input, string expectedAttribute0, string expectedValue0, string expectedAttribute1, string expectedValue1, string expectedAttribute2, string expectedValue2, string expectedAttribute3, string expectedValue3, string expectedAttribute4, string expectedValue4)
+    {
+        var result = XmlTokenParser.ManyElementAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attributes = result.Value;
+        Assert.NotEmpty(attributes);
+        Assert.Equal(5, attributes.Length);
+
+        var attribute0 = attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+        ",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450"
+    )]
+    public void Test6Attributes(
+        string input,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5
+    )
+    {
+        var result = XmlTokenParser.ManyElementAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attributes = result.Value;
+        Assert.NotEmpty(attributes);
+        Assert.Equal(6, attributes.Length);
+
+        var attribute0 = attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+        ",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800"
+    )]
+    public void Test7Attributes(
+        string input,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6
+    )
+    {
+        var result = XmlTokenParser.ManyElementAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attributes = result.Value;
+        Assert.NotEmpty(attributes);
+        Assert.Equal(7, attributes.Length);
+
+        var attribute0 = attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+        ",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d"
+    )]
+    public void Test8Attributes(
+        string input,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7
+    )
+    {
+        var result = XmlTokenParser.ManyElementAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attributes = result.Value;
+        Assert.NotEmpty(attributes);
+        Assert.Equal(8, attributes.Length);
+
+        var attribute0 = attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+        ",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow"
+    )]
+    public void Test9Attributes(
+        string input,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8
+    )
+    {
+        var result = XmlTokenParser.ManyElementAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attributes = result.Value;
+        Assert.NotEmpty(attributes);
+        Assert.Equal(9, attributes.Length);
+
+        var attribute0 = attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+          x:DataType=""vm:MainWindowViewModel""
+        ",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow",
+        "x:DataType",
+        "vm:MainWindowViewModel"
+    )]
+    public void Test10Attributes(
+        string input,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8,
+        string expectedAttribute9,
+        string expectedValue9
+    )
+    {
+        var result = XmlTokenParser.ManyElementAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attributes = result.Value;
+        Assert.NotEmpty(attributes);
+        Assert.Equal(10, attributes.Length);
+
+        var attribute0 = attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+
+        var attribute9 = attributes[9];
+        Assert.NotEmpty(attribute9.Name.ToStringValue());
+        Assert.Equal(expectedAttribute9, attribute9.Name.ToStringValue());
+        Assert.NotNull(attribute9.Value);
+        Assert.NotEmpty(((TextSpan)attribute9.Value!).ToStringValue());
+        Assert.Equal(expectedValue9, ((TextSpan)attribute9.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+          x:DataType=""vm:MainWindowViewModel""
+          Icon=""avares://GitRise/Resources/GitRise.ico""
+        ",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow",
+        "x:DataType",
+        "vm:MainWindowViewModel",
+        "Icon",
+        "avares://GitRise/Resources/GitRise.ico"
+    )]
+    public void Test11Attributes(
+        string input,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8,
+        string expectedAttribute9,
+        string expectedValue9,
+        string expectedAttribute10,
+        string expectedValue10
+    )
+    {
+        var result = XmlTokenParser.ManyElementAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attributes = result.Value;
+        Assert.NotEmpty(attributes);
+        Assert.Equal(11, attributes.Length);
+
+        var attribute0 = attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+
+        var attribute9 = attributes[9];
+        Assert.NotEmpty(attribute9.Name.ToStringValue());
+        Assert.Equal(expectedAttribute9, attribute9.Name.ToStringValue());
+        Assert.NotNull(attribute9.Value);
+        Assert.NotEmpty(((TextSpan)attribute9.Value!).ToStringValue());
+        Assert.Equal(expectedValue9, ((TextSpan)attribute9.Value!).ToStringValue());
+
+        var attribute10 = attributes[10];
+        Assert.NotEmpty(attribute10.Name.ToStringValue());
+        Assert.Equal(expectedAttribute10, attribute10.Name.ToStringValue());
+        Assert.NotNull(attribute10.Value);
+        Assert.NotEmpty(((TextSpan)attribute10.Value!).ToStringValue());
+        Assert.Equal(expectedValue10, ((TextSpan)attribute10.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+          x:DataType=""vm:MainWindowViewModel""
+          Icon=""avares://GitRise/Resources/GitRise.ico""
+          Title=""GitRise""
+        ",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow",
+        "x:DataType",
+        "vm:MainWindowViewModel",
+        "Icon",
+        "avares://GitRise/Resources/GitRise.ico",
+        "Title",
+        "GitRise"
+    )]
+    public void Test12Attributes(
+        string input,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8,
+        string expectedAttribute9,
+        string expectedValue9,
+        string expectedAttribute10,
+        string expectedValue10,
+        string expectedAttribute11,
+        string expectedValue11
+    )
+    {
+        var result = XmlTokenParser.ManyElementAttributesForUnitTestsOnly(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var attributes = result.Value;
+        Assert.NotEmpty(attributes);
+        Assert.Equal(12, attributes.Length);
+
+        var attribute0 = attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+
+        var attribute9 = attributes[9];
+        Assert.NotEmpty(attribute9.Name.ToStringValue());
+        Assert.Equal(expectedAttribute9, attribute9.Name.ToStringValue());
+        Assert.NotNull(attribute9.Value);
+        Assert.NotEmpty(((TextSpan)attribute9.Value!).ToStringValue());
+        Assert.Equal(expectedValue9, ((TextSpan)attribute9.Value!).ToStringValue());
+
+        var attribute10 = attributes[10];
+        Assert.NotEmpty(attribute10.Name.ToStringValue());
+        Assert.Equal(expectedAttribute10, attribute10.Name.ToStringValue());
+        Assert.NotNull(attribute10.Value);
+        Assert.NotEmpty(((TextSpan)attribute10.Value!).ToStringValue());
+        Assert.Equal(expectedValue10, ((TextSpan)attribute10.Value!).ToStringValue());
+
+        var attribute11 = attributes[11];
+        Assert.NotEmpty(attribute11.Name.ToStringValue());
+        Assert.Equal(expectedAttribute11, attribute11.Name.ToStringValue());
+        Assert.NotNull(attribute11.Value);
+        Assert.NotEmpty(((TextSpan)attribute11.Value!).ToStringValue());
+        Assert.Equal(expectedValue11, ((TextSpan)attribute11.Value!).ToStringValue());
+    }
+
+    #endregion
 }

--- a/Tests/SAX.TokenParser.Test/ElementEmptyParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/ElementEmptyParserTest.cs
@@ -160,6 +160,14 @@ public class ElementEmptyParserTest
     [InlineData("<el:em-ent at:tri-bute=\"{hogehoge}\"/>", "el:em-ent", "at:tri-bute", "{hogehoge}")]
     [InlineData("<el:em-en_t at:tri-but_e=\"{hogehoge}\"/>", "el:em-en_t", "at:tri-but_e", "{hogehoge}")]
     [InlineData("<element1 attribute0=\"{hogehoge}\"/>", "element1", "attribute0", "{hogehoge}")]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+        />",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui"
+    )]
     public void TestElementAttribute(string input, string expectedElement, string expectedAttribute, string expectedValue)
     {
         var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
@@ -180,4 +188,1182 @@ public class ElementEmptyParserTest
         Assert.NotEmpty(((TextSpan)attribute.Value!).ToStringValue());
         Assert.Equal(expectedValue, ((TextSpan)attribute.Value!).ToStringValue());
     }
+
+    #region multi attribute tests on real data
+
+    [Theory]
+    [InlineData("<element aaa=\"bbb\" ccc=\"ddd\"/>", "element", "aaa", "bbb", "ccc", "ddd")]
+    [InlineData("<element attribute=\"hogehoge\" at-tribute=\"hogehoge\"/>", "element", "attribute", "hogehoge", "at-tribute", "hogehoge")]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+        />",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008"
+    )]
+    public void TestElement2Attributes(string input, string expectedElement, string expectedAttribute0, string expectedValue0, string expectedAttribute1, string expectedValue1)
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(2, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+        />",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml"
+    )]
+    public void TestElement3Attributes(string input, string expectedElement, string expectedAttribute0, string expectedValue0, string expectedAttribute1, string expectedValue1, string expectedAttribute2, string expectedValue2)
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(3, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+        />",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006"
+    )]
+    public void TestElement4Attributes(string input, string expectedElement, string expectedAttribute0, string expectedValue0, string expectedAttribute1, string expectedValue1, string expectedAttribute2, string expectedValue2, string expectedAttribute3, string expectedValue3)
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(4, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+        />",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise"
+    )]
+    public void TestElement5Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4
+    )
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(5, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+        />",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450"
+    )]
+    public void TestElement6Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5
+    )
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(6, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+        />",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800"
+    )]
+    public void TestElement7Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6
+    )
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(7, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+        />",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d"
+    )]
+    public void TestElement8Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7
+    )
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(8, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+        />",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow"
+    )]
+    public void TestElement9Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8
+    )
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(9, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = element.Attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+          x:DataType=""vm:MainWindowViewModel""
+        />",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow",
+        "x:DataType",
+        "vm:MainWindowViewModel"
+    )]
+    public void TestElement10Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8,
+        string expectedAttribute9,
+        string expectedValue9
+    )
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(10, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = element.Attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+
+        var attribute9 = element.Attributes[9];
+        Assert.NotEmpty(attribute9.Name.ToStringValue());
+        Assert.Equal(expectedAttribute9, attribute9.Name.ToStringValue());
+        Assert.NotNull(attribute9.Value);
+        Assert.NotEmpty(((TextSpan)attribute9.Value!).ToStringValue());
+        Assert.Equal(expectedValue9, ((TextSpan)attribute9.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+          x:DataType=""vm:MainWindowViewModel""
+          Icon=""avares://GitRise/Resources/GitRise.ico""
+        />",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow",
+        "x:DataType",
+        "vm:MainWindowViewModel",
+        "Icon",
+        "avares://GitRise/Resources/GitRise.ico"
+    )]
+    public void TestElement11Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8,
+        string expectedAttribute9,
+        string expectedValue9,
+        string expectedAttribute10,
+        string expectedValue10
+    )
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(11, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = element.Attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+
+        var attribute9 = element.Attributes[9];
+        Assert.NotEmpty(attribute9.Name.ToStringValue());
+        Assert.Equal(expectedAttribute9, attribute9.Name.ToStringValue());
+        Assert.NotNull(attribute9.Value);
+        Assert.NotEmpty(((TextSpan)attribute9.Value!).ToStringValue());
+        Assert.Equal(expectedValue9, ((TextSpan)attribute9.Value!).ToStringValue());
+
+        var attribute10 = element.Attributes[10];
+        Assert.NotEmpty(attribute10.Name.ToStringValue());
+        Assert.Equal(expectedAttribute10, attribute10.Name.ToStringValue());
+        Assert.NotNull(attribute10.Value);
+        Assert.NotEmpty(((TextSpan)attribute10.Value!).ToStringValue());
+        Assert.Equal(expectedValue10, ((TextSpan)attribute10.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+          x:DataType=""vm:MainWindowViewModel""
+          Icon=""avares://GitRise/Resources/GitRise.ico""
+          Title=""GitRise""
+        />",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow",
+        "x:DataType",
+        "vm:MainWindowViewModel",
+        "Icon",
+        "avares://GitRise/Resources/GitRise.ico",
+        "Title",
+        "GitRise"
+    )]
+    public void TestElement12Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8,
+        string expectedAttribute9,
+        string expectedValue9,
+        string expectedAttribute10,
+        string expectedValue10,
+        string expectedAttribute11,
+        string expectedValue11
+    )
+    {
+        var result = XmlTokenParser.ElementEmpty(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(12, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = element.Attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+
+        var attribute9 = element.Attributes[9];
+        Assert.NotEmpty(attribute9.Name.ToStringValue());
+        Assert.Equal(expectedAttribute9, attribute9.Name.ToStringValue());
+        Assert.NotNull(attribute9.Value);
+        Assert.NotEmpty(((TextSpan)attribute9.Value!).ToStringValue());
+        Assert.Equal(expectedValue9, ((TextSpan)attribute9.Value!).ToStringValue());
+
+        var attribute10 = element.Attributes[10];
+        Assert.NotEmpty(attribute10.Name.ToStringValue());
+        Assert.Equal(expectedAttribute10, attribute10.Name.ToStringValue());
+        Assert.NotNull(attribute10.Value);
+        Assert.NotEmpty(((TextSpan)attribute10.Value!).ToStringValue());
+        Assert.Equal(expectedValue10, ((TextSpan)attribute10.Value!).ToStringValue());
+
+        var attribute11 = element.Attributes[11];
+        Assert.NotEmpty(attribute11.Name.ToStringValue());
+        Assert.Equal(expectedAttribute11, attribute11.Name.ToStringValue());
+        Assert.NotNull(attribute11.Value);
+        Assert.NotEmpty(((TextSpan)attribute11.Value!).ToStringValue());
+        Assert.Equal(expectedValue11, ((TextSpan)attribute11.Value!).ToStringValue());
+    }
+
+    #endregion
 }

--- a/Tests/SAX.TokenParser.Test/ElementStartParserTest.cs
+++ b/Tests/SAX.TokenParser.Test/ElementStartParserTest.cs
@@ -160,6 +160,14 @@ public class ElementStartParserTest
     [InlineData("<el:em-ent at:tri-bute=\"{hogehoge}\">", "el:em-ent", "at:tri-bute", "{hogehoge}")]
     [InlineData("<el:em-en_t at:tri-but_e=\"{hogehoge}\">", "el:em-en_t", "at:tri-but_e", "{hogehoge}")]
     [InlineData("<element1 attribute0=\"{hogehoge}\">", "element1", "attribute0", "{hogehoge}")]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+        >",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui"
+    )]
     public void TestElementAttribute(string input, string expectedElement, string expectedAttribute, string expectedValue)
     {
         var result = XmlTokenParser.ElementStart(new TextSpan(input));
@@ -180,4 +188,1182 @@ public class ElementStartParserTest
         Assert.NotEmpty(((TextSpan)attribute.Value!).ToStringValue());
         Assert.Equal(expectedValue, ((TextSpan)attribute.Value!).ToStringValue());
     }
+
+    #region multi attribute tests on real data
+
+    [Theory]
+    [InlineData("<element aaa=\"bbb\" ccc=\"ddd\">", "element", "aaa", "bbb", "ccc", "ddd")]
+    [InlineData("<element attribute=\"hogehoge\" at-tribute=\"hogehoge\">", "element", "attribute", "hogehoge", "at-tribute", "hogehoge")]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+        >",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008"
+    )]
+    public void TestElement2Attributes(string input, string expectedElement, string expectedAttribute0, string expectedValue0, string expectedAttribute1, string expectedValue1)
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(2, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+        >",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml"
+    )]
+    public void TestElement3Attributes(string input, string expectedElement, string expectedAttribute0, string expectedValue0, string expectedAttribute1, string expectedValue1, string expectedAttribute2, string expectedValue2)
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(3, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+        >",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006"
+    )]
+    public void TestElement4Attributes(string input, string expectedElement, string expectedAttribute0, string expectedValue0, string expectedAttribute1, string expectedValue1, string expectedAttribute2, string expectedValue2, string expectedAttribute3, string expectedValue3)
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(4, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+        >",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise"
+    )]
+    public void TestElement5Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4
+    )
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(5, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+        >",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450"
+    )]
+    public void TestElement6Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5
+    )
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(6, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+        >",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800"
+    )]
+    public void TestElement7Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6
+    )
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(7, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+        >",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d"
+    )]
+    public void TestElement8Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7
+    )
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(8, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+        >",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow"
+    )]
+    public void TestElement9Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8
+    )
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(9, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = element.Attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+          x:DataType=""vm:MainWindowViewModel""
+        >",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow",
+        "x:DataType",
+        "vm:MainWindowViewModel"
+    )]
+    public void TestElement10Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8,
+        string expectedAttribute9,
+        string expectedValue9
+    )
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(10, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = element.Attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+
+        var attribute9 = element.Attributes[9];
+        Assert.NotEmpty(attribute9.Name.ToStringValue());
+        Assert.Equal(expectedAttribute9, attribute9.Name.ToStringValue());
+        Assert.NotNull(attribute9.Value);
+        Assert.NotEmpty(((TextSpan)attribute9.Value!).ToStringValue());
+        Assert.Equal(expectedValue9, ((TextSpan)attribute9.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+          x:DataType=""vm:MainWindowViewModel""
+          Icon=""avares://GitRise/Resources/GitRise.ico""
+        >",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow",
+        "x:DataType",
+        "vm:MainWindowViewModel",
+        "Icon",
+        "avares://GitRise/Resources/GitRise.ico"
+    )]
+    public void TestElement11Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8,
+        string expectedAttribute9,
+        string expectedValue9,
+        string expectedAttribute10,
+        string expectedValue10
+    )
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(11, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = element.Attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+
+        var attribute9 = element.Attributes[9];
+        Assert.NotEmpty(attribute9.Name.ToStringValue());
+        Assert.Equal(expectedAttribute9, attribute9.Name.ToStringValue());
+        Assert.NotNull(attribute9.Value);
+        Assert.NotEmpty(((TextSpan)attribute9.Value!).ToStringValue());
+        Assert.Equal(expectedValue9, ((TextSpan)attribute9.Value!).ToStringValue());
+
+        var attribute10 = element.Attributes[10];
+        Assert.NotEmpty(attribute10.Name.ToStringValue());
+        Assert.Equal(expectedAttribute10, attribute10.Name.ToStringValue());
+        Assert.NotNull(attribute10.Value);
+        Assert.NotEmpty(((TextSpan)attribute10.Value!).ToStringValue());
+        Assert.Equal(expectedValue10, ((TextSpan)attribute10.Value!).ToStringValue());
+    }
+
+    [Theory]
+    [InlineData(
+        @"<Window
+          xmlns=""https://github.com/avaloniaui""
+          xmlns:d=""http://schemas.microsoft.com/expression/blend/2008""
+          xmlns:x=""http://schemas.microsoft.com/winfx/2006/xaml""
+          xmlns:mc=""http://schemas.openxmlformats.org/markup-compatibility/2006""
+          xmlns:vm=""using:GitRise""
+          d:DesignHeight=""450""
+          d:DesignWidth=""800""
+          mc:Ignorable=""d""
+          x:Class=""GitRise.MainWindow""
+          x:DataType=""vm:MainWindowViewModel""
+          Icon=""avares://GitRise/Resources/GitRise.ico""
+          Title=""GitRise""
+        >",
+        "Window",
+        "xmlns",
+        "https://github.com/avaloniaui",
+        "xmlns:d",
+        "http://schemas.microsoft.com/expression/blend/2008",
+        "xmlns:x",
+        "http://schemas.microsoft.com/winfx/2006/xaml",
+        "xmlns:mc",
+        "http://schemas.openxmlformats.org/markup-compatibility/2006",
+        "xmlns:vm",
+        "using:GitRise",
+        "d:DesignHeight",
+        "450",
+        "d:DesignWidth",
+        "800",
+        "mc:Ignorable",
+        "d",
+        "x:Class",
+        "GitRise.MainWindow",
+        "x:DataType",
+        "vm:MainWindowViewModel",
+        "Icon",
+        "avares://GitRise/Resources/GitRise.ico",
+        "Title",
+        "GitRise"
+    )]
+    public void TestElement12Attributes(
+        string input,
+        string expectedElement,
+        string expectedAttribute0,
+        string expectedValue0,
+        string expectedAttribute1,
+        string expectedValue1,
+        string expectedAttribute2,
+        string expectedValue2,
+        string expectedAttribute3,
+        string expectedValue3,
+        string expectedAttribute4,
+        string expectedValue4,
+        string expectedAttribute5,
+        string expectedValue5,
+        string expectedAttribute6,
+        string expectedValue6,
+        string expectedAttribute7,
+        string expectedValue7,
+        string expectedAttribute8,
+        string expectedValue8,
+        string expectedAttribute9,
+        string expectedValue9,
+        string expectedAttribute10,
+        string expectedValue10,
+        string expectedAttribute11,
+        string expectedValue11
+    )
+    {
+        var result = XmlTokenParser.ElementStart(new TextSpan(input));
+        Console.WriteLine($"parsing: `{input}`\nresult: {result}");
+
+        Assert.Null(result.ErrorMessage);
+        Assert.True(result.HasValue);
+
+        var element = result.Value;
+        Assert.NotEmpty(element.Identifier.ToStringValue());
+        Assert.Equal(expectedElement, element.Identifier.ToStringValue());
+
+        Assert.NotEmpty(element.Attributes);
+        Assert.Equal(12, element.Attributes.Length);
+
+        var attribute0 = element.Attributes[0];
+        Assert.NotEmpty(attribute0.Name.ToStringValue());
+        Assert.Equal(expectedAttribute0, attribute0.Name.ToStringValue());
+        Assert.NotNull(attribute0.Value);
+        Assert.NotEmpty(((TextSpan)attribute0.Value!).ToStringValue());
+        Assert.Equal(expectedValue0, ((TextSpan)attribute0.Value!).ToStringValue());
+
+        var attribute1 = element.Attributes[1];
+        Assert.NotEmpty(attribute1.Name.ToStringValue());
+        Assert.Equal(expectedAttribute1, attribute1.Name.ToStringValue());
+        Assert.NotNull(attribute1.Value);
+        Assert.NotEmpty(((TextSpan)attribute1.Value!).ToStringValue());
+        Assert.Equal(expectedValue1, ((TextSpan)attribute1.Value!).ToStringValue());
+
+        var attribute2 = element.Attributes[2];
+        Assert.NotEmpty(attribute2.Name.ToStringValue());
+        Assert.Equal(expectedAttribute2, attribute2.Name.ToStringValue());
+        Assert.NotNull(attribute2.Value);
+        Assert.NotEmpty(((TextSpan)attribute2.Value!).ToStringValue());
+        Assert.Equal(expectedValue2, ((TextSpan)attribute2.Value!).ToStringValue());
+
+        var attribute3 = element.Attributes[3];
+        Assert.NotEmpty(attribute3.Name.ToStringValue());
+        Assert.Equal(expectedAttribute3, attribute3.Name.ToStringValue());
+        Assert.NotNull(attribute3.Value);
+        Assert.NotEmpty(((TextSpan)attribute3.Value!).ToStringValue());
+        Assert.Equal(expectedValue3, ((TextSpan)attribute3.Value!).ToStringValue());
+
+        var attribute4 = element.Attributes[4];
+        Assert.NotEmpty(attribute4.Name.ToStringValue());
+        Assert.Equal(expectedAttribute4, attribute4.Name.ToStringValue());
+        Assert.NotNull(attribute4.Value);
+        Assert.NotEmpty(((TextSpan)attribute4.Value!).ToStringValue());
+        Assert.Equal(expectedValue4, ((TextSpan)attribute4.Value!).ToStringValue());
+
+        var attribute5 = element.Attributes[5];
+        Assert.NotEmpty(attribute5.Name.ToStringValue());
+        Assert.Equal(expectedAttribute5, attribute5.Name.ToStringValue());
+        Assert.NotNull(attribute5.Value);
+        Assert.NotEmpty(((TextSpan)attribute5.Value!).ToStringValue());
+        Assert.Equal(expectedValue5, ((TextSpan)attribute5.Value!).ToStringValue());
+
+        var attribute6 = element.Attributes[6];
+        Assert.NotEmpty(attribute6.Name.ToStringValue());
+        Assert.Equal(expectedAttribute6, attribute6.Name.ToStringValue());
+        Assert.NotNull(attribute6.Value);
+        Assert.NotEmpty(((TextSpan)attribute6.Value!).ToStringValue());
+        Assert.Equal(expectedValue6, ((TextSpan)attribute6.Value!).ToStringValue());
+
+        var attribute7 = element.Attributes[7];
+        Assert.NotEmpty(attribute7.Name.ToStringValue());
+        Assert.Equal(expectedAttribute7, attribute7.Name.ToStringValue());
+        Assert.NotNull(attribute7.Value);
+        Assert.NotEmpty(((TextSpan)attribute7.Value!).ToStringValue());
+        Assert.Equal(expectedValue7, ((TextSpan)attribute7.Value!).ToStringValue());
+
+        var attribute8 = element.Attributes[8];
+        Assert.NotEmpty(attribute8.Name.ToStringValue());
+        Assert.Equal(expectedAttribute8, attribute8.Name.ToStringValue());
+        Assert.NotNull(attribute8.Value);
+        Assert.NotEmpty(((TextSpan)attribute8.Value!).ToStringValue());
+        Assert.Equal(expectedValue8, ((TextSpan)attribute8.Value!).ToStringValue());
+
+        var attribute9 = element.Attributes[9];
+        Assert.NotEmpty(attribute9.Name.ToStringValue());
+        Assert.Equal(expectedAttribute9, attribute9.Name.ToStringValue());
+        Assert.NotNull(attribute9.Value);
+        Assert.NotEmpty(((TextSpan)attribute9.Value!).ToStringValue());
+        Assert.Equal(expectedValue9, ((TextSpan)attribute9.Value!).ToStringValue());
+
+        var attribute10 = element.Attributes[10];
+        Assert.NotEmpty(attribute10.Name.ToStringValue());
+        Assert.Equal(expectedAttribute10, attribute10.Name.ToStringValue());
+        Assert.NotNull(attribute10.Value);
+        Assert.NotEmpty(((TextSpan)attribute10.Value!).ToStringValue());
+        Assert.Equal(expectedValue10, ((TextSpan)attribute10.Value!).ToStringValue());
+
+        var attribute11 = element.Attributes[11];
+        Assert.NotEmpty(attribute11.Name.ToStringValue());
+        Assert.Equal(expectedAttribute11, attribute11.Name.ToStringValue());
+        Assert.NotNull(attribute11.Value);
+        Assert.NotEmpty(((TextSpan)attribute11.Value!).ToStringValue());
+        Assert.Equal(expectedValue11, ((TextSpan)attribute11.Value!).ToStringValue());
+    }
+
+    #endregion
 }

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -65,6 +65,7 @@ public static class XmlTokenParser
     internal static TextParser<Attribute> ElementAttribute { get; } =
         from identifier in XmlChars
         from value in Span.EqualTo("=").IgnoreThen(QuotedString).Optional()
+        from trailing in Span.WhiteSpace.Many()
         select new Attribute(identifier, value);
 
     internal static TextParser<Attribute[]> ManyElementAttributes { get; } =

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -67,6 +67,9 @@ public static class XmlTokenParser
         from value in Span.EqualTo("=").IgnoreThen(QuotedString).Optional()
         select new Attribute(identifier, value);
 
+    internal static TextParser<Attribute[]> ManyElementAttributes { get; } =
+        ElementAttribute.Many();
+
     public static TextParser<Attribute> ElementAttributeForUnitTestsOnly
     {
         get => ElementAttribute;

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -84,7 +84,7 @@ public static class XmlTokenParser
 
     public static TextParser<Element> ElementAndAttributesForUnitTestsOnly { get; } =
         from identifier in ElementIdentifier
-        from attributes in Character.WhiteSpace.Many().IgnoreThen(ElementAttribute.Many())
+        from attributes in Character.WhiteSpace.Many().IgnoreThen(ManyElementAttributes)
         select new Element(identifier, attributes);
 
     public static TextParser<Element> ElementStart { get; } =

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -89,7 +89,7 @@ public static class XmlTokenParser
 
     public static TextParser<Element> ElementStart { get; } =
         from identifier in ElementIdentifier
-        from attributes in Character.WhiteSpace.Many().IgnoreThen(ElementAttribute.Many())
+        from attributes in Character.WhiteSpace.Many().IgnoreThen(ManyElementAttributes)
         from closing in Character.WhiteSpace.Many().IgnoreThen(Character.EqualTo('>'))
         select new Element(identifier, attributes);
 

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -95,7 +95,7 @@ public static class XmlTokenParser
 
     public static TextParser<Element> ElementEmpty { get; } =
         from identifier in ElementIdentifier
-        from attributes in Character.WhiteSpace.Many().IgnoreThen(ElementAttribute.Many())
+        from attributes in Character.WhiteSpace.Many().IgnoreThen(ManyElementAttributes)
         from closing in Character.WhiteSpace.Many().IgnoreThen(Span.EqualTo("/>"))
         select new Element(identifier, attributes);
 

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -69,7 +69,7 @@ public static class XmlTokenParser
         select new Attribute(identifier, value);
 
     internal static TextParser<Attribute[]> ManyElementAttributes { get; } =
-        ElementAttribute.Many();
+        Span.WhiteSpace.Many().IgnoreThen(ElementAttribute).Many();
 
     public static TextParser<Attribute> ElementAttributeForUnitTestsOnly
     {

--- a/XmlFormat.SAX/TokenParser.cs
+++ b/XmlFormat.SAX/TokenParser.cs
@@ -75,7 +75,10 @@ public static class XmlTokenParser
         get => ElementAttribute;
     }
 
-    public static TextParser<Attribute[]> ManyElementAttributesForUnitTestsOnly { get; } = ElementAttribute.Many();
+    public static TextParser<Attribute[]> ManyElementAttributesForUnitTestsOnly
+    {
+        get => ManyElementAttributes;
+    }
 
     public record struct Element(TextSpan Identifier, Attribute[] Attributes);
 


### PR DESCRIPTION
- **feat: implement ElementEmpty-specific token parser unit tests with 2-12 attributes**
- **feat: implement ElementStart-specific token parser unit tests with 2-12 attributes**
- **feat: implement ElementAndAttributes-specific token parser unit tests with 2-12 attributes**
- **feat: implement Attributes-specific token parser unit tests with 2-12 attributes**
- **feat: implement internal ManyElementAttributes parser**
- **refactor: redirect ManyElementAttributesForUnitTestsOnly parser to ManyElementAttributes one**
- **refactor: use ManyElementAttributes parser instead of ElementAttribute.Many() in ElementAndAttributesForUnitTestsOnly parser**
- **refactor: use ManyElementAttributes parser instead of ElementAttribute.Many() in ElementStart parser**
- **refactor: use ManyElementAttributes parser instead of ElementAttribute.Many() in ElementEmpty parser**
- **fix: allow (but ignore) whitespace following QuotedString in ElementAttribute parser**
- **fix: allow (but ignore) whitespace preceding ElementAttribute in ManyElementAttributes parser**
