### PR TITLE
fix: preserve document identity in XmlFormat.Format()

### DIFF
--- a/Tests/SAX.EventHandler.Test/ResourceTest.cs
+++ b/Tests/SAX.EventHandler.Test/ResourceTest.cs
@@ -1,10 +1,9 @@
-using Superpower.Parsers;
 using System.Diagnostics.CodeAnalysis;
+using Superpower.Parsers;
 using XmlFormat.SAX;
 using XmlFormat.Test.Assets;
 
 [assembly: SuppressMessage("xUnit", "xUnit1013", Justification = "Test class is correctly implementing an interface.")]
-
 
 namespace SAX.EventHandler.Test;
 

--- a/XmlFormat.Lib/FormattingXmlReadHandler.cs
+++ b/XmlFormat.Lib/FormattingXmlReadHandler.cs
@@ -231,7 +231,6 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
 
 internal static class IEnumerableOfAttributesExtensions
 {
-    public static int SingleLineLength(
-        this IEnumerable<FormattingXmlReadHandler.Attribute> attributes
-    ) => attributes.Sum(k => k.Name.Length + k.Value.Length + 4); //< ' =""' are the 4 extra chars
+    public static int SingleLineLength(this IEnumerable<FormattingXmlReadHandler.Attribute> attributes) =>
+        attributes.Sum(k => k.Name.Length + k.Value.Length + 4); //< ' =""' are the 4 extra chars
 }

--- a/XmlFormat.Lib/FormattingXmlReadHandler.cs
+++ b/XmlFormat.Lib/FormattingXmlReadHandler.cs
@@ -122,7 +122,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
             currentAttributes.Sort(Attribute.Compare);
             if (currentAttributes.SingleLineLength() > Options.LineLength)
             {
-                textWriter.WriteLine("");
+                textWriter.WriteLine();
                 textWriter.Indent++;
                 foreach (var attribute in currentAttributes)
                 {
@@ -190,7 +190,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         if (!string.IsNullOrEmpty(trimText))
             writer.WriteLine(trimText);
         if (text.ToString().Split('\n').Length > 2) //< 1 empty line = 2x \n, 2 empty lines = 3x \n
-            writer.WriteLine("");
+            textWriter.WriteLineNoTabs();
         textWriter.Flush();
     }
 

--- a/XmlFormat.Lib/FormattingXmlReadHandler.cs
+++ b/XmlFormat.Lib/FormattingXmlReadHandler.cs
@@ -219,11 +219,10 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         if (requireClosingPreviousElementTag)
             OnBeginTagClose();
 
-        textWriter.Indent++;
-        textWriter.Write("<![CDATA[");
-        textWriter.WriteLine(cdata);
+        textWriter.WriteLine("<![CDATA[");
+        textWriter.WriteLineNoTabs(cdata.ToString().Trim('\n').TrimEnd());
+        textWriter.WriteTabs();
         textWriter.WriteLine("]]>");
-        textWriter.Indent--;
         textWriter.Flush();
     }
 

--- a/XmlFormat.Lib/FormattingXmlReadHandler.cs
+++ b/XmlFormat.Lib/FormattingXmlReadHandler.cs
@@ -188,7 +188,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
 
         var trimText = text.ToString().Trim();
         if (!string.IsNullOrEmpty(trimText))
-            writer.WriteLine(trimText);
+            textWriter.WriteLineNoTabs(trimText);
         if (text.ToString().Split('\n').Length > 2) //< 1 empty line = 2x \n, 2 empty lines = 3x \n
             textWriter.WriteLineNoTabs();
         textWriter.Flush();

--- a/XmlFormat.Lib/FormattingXmlReadHandler.cs
+++ b/XmlFormat.Lib/FormattingXmlReadHandler.cs
@@ -102,6 +102,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         }
 
         textWriter.WriteLineNoTabs(" ?>");
+        textWriter.Flush();
     }
 
     public override void OnBeginTag(ReadOnlySpan<char> name, int line, int column)
@@ -111,6 +112,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
 
         requireClosingPreviousElementTag = true;
         textWriter.Write($"<{name}");
+        textWriter.Flush();
     }
 
     public virtual void OnBeginTagClose()
@@ -145,6 +147,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         }
 
         textWriter.Indent++;
+        textWriter.Flush();
     }
 
     public override void OnEndTagEmpty()
@@ -155,12 +158,14 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         textWriter.Indent--;
 
         textWriter.WriteLine($"{(multiLineAttributes ? "" : " ")}/>");
+        textWriter.Flush();
     }
 
     public override void OnEndTag(ReadOnlySpan<char> name, int line, int column)
     {
         textWriter.Indent--;
         textWriter.WriteLine($"</{name}>");
+        textWriter.Flush();
     }
 
     public override void OnAttribute(
@@ -186,6 +191,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
             writer.WriteLine(trimText);
         if (text.ToString().Split('\n').Length > 2) //< 1 empty line = 2x \n, 2 empty lines = 3x \n
             writer.WriteLine("");
+        textWriter.Flush();
     }
 
     public override void OnComment(ReadOnlySpan<char> comment, int line, int column)
@@ -205,6 +211,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
             textWriter.Indent--;
             textWriter.WriteLine("-->");
         }
+        textWriter.Flush();
     }
 
     public override void OnCData(ReadOnlySpan<char> cdata, int line, int column)
@@ -217,6 +224,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         textWriter.WriteLine(cdata);
         textWriter.WriteLine("]]>");
         textWriter.Indent--;
+        textWriter.Flush();
     }
 
     #endregion

--- a/XmlFormat.Lib/FormattingXmlReadHandler.cs
+++ b/XmlFormat.Lib/FormattingXmlReadHandler.cs
@@ -84,15 +84,24 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         int column
     )
     {
-        textWriter.Write(@$"<?xml version=""{version}"" encoding=""{encoding}""");
+        textWriter.WriteNoTabs(@$"<?xml");
+
+        if (!version.IsEmpty)
+        {
+            textWriter.WriteNoTabs(@$" version=""{version}""");
+        }
+
+        if (!encoding.IsEmpty)
+        {
+            textWriter.WriteNoTabs(@$" encoding=""{encoding}""");
+        }
 
         if (!standalone.IsEmpty)
         {
-            textWriter.Write(@$" standalone=""{standalone}""");
+            textWriter.WriteNoTabs(@$" standalone=""{standalone}""");
         }
 
-        textWriter.WriteLine(" ?>");
-        textWriter.WriteLine("");
+        textWriter.WriteLineNoTabs(" ?>");
     }
 
     public override void OnBeginTag(ReadOnlySpan<char> name, int line, int column)

--- a/XmlFormat.Lib/IndentedTextWriterExtension.cs
+++ b/XmlFormat.Lib/IndentedTextWriterExtension.cs
@@ -6,6 +6,14 @@ public static class IndentedTextWriterExtension
 {
     public static void WriteTabs(this IndentedTextWriter writer) => writer.Write("");
 
+    public static void WriteNoTabs(this IndentedTextWriter writer, string s)
+    {
+        var indent = writer.Indent;
+        writer.Indent = 0;
+        writer.Write(s);
+        writer.Indent = indent;
+    }
+
     public static void WriteLine(this IndentedTextWriter writer) => writer.WriteLineNoTabs("");
 
     public static void WriteLineNoTabs(this IndentedTextWriter writer) => writer.WriteLineNoTabs("");

--- a/XmlFormat.Lib/IndentedTextWriterExtension.cs
+++ b/XmlFormat.Lib/IndentedTextWriterExtension.cs
@@ -7,4 +7,6 @@ public static class IndentedTextWriterExtension
     public static void WriteTabs(this IndentedTextWriter writer) => writer.Write("");
 
     public static void WriteLine(this IndentedTextWriter writer) => writer.WriteLineNoTabs("");
+
+    public static void WriteLineNoTabs(this IndentedTextWriter writer) => writer.WriteLineNoTabs("");
 }

--- a/XmlFormat.Lib/IndentedTextWriterExtension.cs
+++ b/XmlFormat.Lib/IndentedTextWriterExtension.cs
@@ -1,0 +1,8 @@
+using System.CodeDom.Compiler;
+
+namespace XmlFormat;
+
+public static class IndentedTextWriterExtension
+{
+    public static void WriteTabs(this IndentedTextWriter writer) => writer.Write("");
+}

--- a/XmlFormat.Lib/IndentedTextWriterExtension.cs
+++ b/XmlFormat.Lib/IndentedTextWriterExtension.cs
@@ -5,4 +5,6 @@ namespace XmlFormat;
 public static class IndentedTextWriterExtension
 {
     public static void WriteTabs(this IndentedTextWriter writer) => writer.Write("");
+
+    public static void WriteLine(this IndentedTextWriter writer) => writer.WriteLineNoTabs("");
 }

--- a/XmlFormat.Lib/XmlFormat.cs
+++ b/XmlFormat.Lib/XmlFormat.cs
@@ -10,11 +10,7 @@ public static class XmlFormat
 
     public static void Format(Stream inputStream, Stream outputStream, FormattingOptions options)
     {
-        using var handler = new FormattingXmlReadHandler(
-            stream: outputStream,
-            encoding: Encoding.UTF8,
-            options: options
-        );
+        var handler = new FormattingXmlReadHandler(stream: outputStream, encoding: encoding, options: options);
         XmlParser.Parse(inputStream, handler, options: new XmlParserOptions(Encoding: encoding));
     }
 

--- a/XmlFormat.Lib/XmlFormat.cs
+++ b/XmlFormat.Lib/XmlFormat.cs
@@ -6,6 +6,8 @@ namespace XmlFormat;
 
 public static class XmlFormat
 {
+    internal static readonly Encoding encoding = new UTF8Encoding(false);
+
     public static void Format(Stream inputStream, Stream outputStream, FormattingOptions options)
     {
         using var handler = new FormattingXmlReadHandler(
@@ -13,14 +15,15 @@ public static class XmlFormat
             encoding: Encoding.UTF8,
             options: options
         );
-        XmlParser.Parse(inputStream, handler);
+        XmlParser.Parse(inputStream, handler, options: new XmlParserOptions(Encoding: encoding));
     }
 
     public static string Format(string xml, FormattingOptions options)
     {
-        using Stream xmlStream = new MemoryStream(Encoding.UTF8.GetBytes(xml) ?? new byte[0]);
-        using Stream outStream = new MemoryStream();
+        using MemoryStream xmlStream = new(encoding.GetBytes(xml));
+        using MemoryStream outStream = new();
         Format(inputStream: xmlStream, outputStream: outStream, options: options);
-        return outStream.ToString() ?? "";
+        outStream.Flush();
+        return encoding.GetString(outStream.ToArray());
     }
 }

--- a/XmlFormat.Lib/XmlReadHandlerBase.cs
+++ b/XmlFormat.Lib/XmlReadHandlerBase.cs
@@ -9,7 +9,7 @@ public class XmlReadHandlerBase : IXmlReadHandler, IDisposable
     protected readonly StreamWriter writer;
 
     public XmlReadHandlerBase(Stream stream, Encoding encoding)
-        : this(new StreamWriter(stream, encoding) { AutoFlush = true, }) { }
+        : this(new StreamWriter(stream, encoding, leaveOpen: true) { AutoFlush = true, }) { }
 
     public XmlReadHandlerBase(StreamWriter streamWriter)
     {

--- a/XmlFormat.Lib/XmlReadHandlerBase.cs
+++ b/XmlFormat.Lib/XmlReadHandlerBase.cs
@@ -56,10 +56,7 @@ public class XmlReadHandlerBase : IXmlReadHandler, IDisposable
         int nameColumn,
         int valueLine,
         int valueColumn
-    ) =>
-        writer.WriteLine(
-            $"Attribute({nameLine + 1}:{nameColumn + 1})-({valueLine + 1}:{valueColumn + 1}): {name}=\"{value}\""
-        );
+    ) => writer.WriteLine($"Attribute({nameLine + 1}:{nameColumn + 1})-({valueLine + 1}:{valueColumn + 1}): {name}=\"{value}\"");
 
     public virtual void OnText(ReadOnlySpan<char> text, int line, int column) =>
         writer.WriteLine($"Content({line + 1}:{column + 1}): {text}");

--- a/XmlFormat.Tool/Program.cs
+++ b/XmlFormat.Tool/Program.cs
@@ -60,7 +60,6 @@ public class Program
             }
             Console.WriteLine($"actual formattingOptions: {actualFormattingOptions}");
 
-
             using (Stream istream = OpenInputStreamOrStdIn(inputFile, options.Inline))
             using (Stream ostream = OpenOutputStreamOrStdOut(inputFile, options.Inline))
             {


### PR DESCRIPTION
- **feat: implement IndentedTextWriter.WriteTabs() extension method taking no arguments**
- **feat: implement IndentedTextWriter.WriteLine() extension method taking no arguments**
- **feat: implement IndentedTextWriter.WriteLineNoTabs() extension method taking no arguments**
- **feat: implement IndentedTextWriter.WriteNoTabs() extension method**
- **fix: create StreamWriter with flag 'leaveOpen:true' in XmlReadHandlerBase.ctor()**
- **refactor: write XML Declaration using IndentedTextWriter but without indentation**
- **refactor: flush IndentedTextWriter after writing**
- **refactor: write formatted CData without indentation while trimming leading newlines and trailing whitespace**
- **refactor: simplify IndentedTextWriter calls using extension methods without arguments**
- **refactor: write formatted text nodes without indentation**
- **chore: apply CSharpier formatting**
- **refactor: use common Encoding instance to write BOM-less UTF8**
- **fix: avoid closing Stream by not disposing FormattingXmlReadHandler instance immediately**
