### PR TITLE
refactor: check Tokenizer for raised exceptions in SAX.Tokenizer.Tests

### DIFF
--- a/Tests/SAX.Tokenizer.Test/NegativeTokenizerTests.cs
+++ b/Tests/SAX.Tokenizer.Test/NegativeTokenizerTests.cs
@@ -11,141 +11,141 @@ public class NegativeTokenizerTest
     [Fact]
     public void NegativeTestProcessingInstruction()
     {
-        Assert.False(TestHelper.Tokenize("<?xml>", [XmlTokenizer.XmlToken.Declaration]));
-        Assert.False(TestHelper.Tokenize("<?xml ", [XmlTokenizer.XmlToken.Declaration]));
-        Assert.False(TestHelper.Tokenize("<?xml version=\"1.0\" encoding=\"utf-8\">", [XmlTokenizer.XmlToken.Declaration]));
-        Assert.False(TestHelper.Tokenize("<?xml version=\"1.0\" encoding=\"utf-8\" ", [XmlTokenizer.XmlToken.Declaration]));
-        Assert.False(TestHelper.Tokenize("<?php>", [XmlTokenizer.XmlToken.ProcessingInstruction]));
-        Assert.False(TestHelper.Tokenize("<?php ", [XmlTokenizer.XmlToken.ProcessingInstruction]));
+        Assert.False(TestHelper.FailTokenize("<?xml>", [XmlTokenizer.XmlToken.Declaration]));
+        Assert.False(TestHelper.FailTokenize("<?xml ", [XmlTokenizer.XmlToken.Declaration]));
+        Assert.False(TestHelper.FailTokenize("<?xml version=\"1.0\" encoding=\"utf-8\">", [XmlTokenizer.XmlToken.Declaration]));
+        Assert.False(TestHelper.FailTokenize("<?xml version=\"1.0\" encoding=\"utf-8\" ", [XmlTokenizer.XmlToken.Declaration]));
+        Assert.False(TestHelper.FailTokenize("<?php>", [XmlTokenizer.XmlToken.ProcessingInstruction]));
+        Assert.False(TestHelper.FailTokenize("<?php ", [XmlTokenizer.XmlToken.ProcessingInstruction]));
     }
 
     [Fact]
     public void NegativeTestComment()
     {
-        Assert.False(TestHelper.Tokenize("<!--->", [XmlTokenizer.XmlToken.Comment]));
-        Assert.False(TestHelper.Tokenize("<!-- ->", [XmlTokenizer.XmlToken.Comment]));
-        Assert.False(TestHelper.Tokenize("<!--\n->", [XmlTokenizer.XmlToken.Comment]));
-        Assert.False(TestHelper.Tokenize("<!--comment->", [XmlTokenizer.XmlToken.Comment]));
-        Assert.False(TestHelper.Tokenize("<!--comment --", [XmlTokenizer.XmlToken.Comment]));
-        Assert.False(TestHelper.Tokenize("<!-- comment>", [XmlTokenizer.XmlToken.Comment]));
-        Assert.False(TestHelper.Tokenize("<!-- comment ", [XmlTokenizer.XmlToken.Comment]));
-        Assert.False(TestHelper.Tokenize("<!--\ncomment\nmore comment\n", [XmlTokenizer.XmlToken.Comment]));
-        Assert.False(TestHelper.Tokenize("<!--\ncomment\nmore comment\n ", [XmlTokenizer.XmlToken.Comment]));
-        Assert.False(TestHelper.Tokenize("<!-- \ncomment\nmore comment\n->", [XmlTokenizer.XmlToken.Comment]));
-        Assert.False(TestHelper.Tokenize("<!-- \ncomment\nmore comment\n >", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.FailTokenize("<!--->", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.FailTokenize("<!-- ->", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.FailTokenize("<!--\n->", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.FailTokenize("<!--comment->", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.FailTokenize("<!--comment --", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.FailTokenize("<!-- comment>", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.FailTokenize("<!-- comment ", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.FailTokenize("<!--\ncomment\nmore comment\n", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.FailTokenize("<!--\ncomment\nmore comment\n ", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.FailTokenize("<!-- \ncomment\nmore comment\n->", [XmlTokenizer.XmlToken.Comment]));
+        Assert.False(TestHelper.FailTokenize("<!-- \ncomment\nmore comment\n >", [XmlTokenizer.XmlToken.Comment]));
     }
 
     [Fact]
     public void NegativeTestCData()
     {
-        Assert.False(TestHelper.Tokenize("<![CDATA[]>", [XmlTokenizer.XmlToken.CData]));
-        Assert.False(TestHelper.Tokenize("<![CDATA[ ]]", [XmlTokenizer.XmlToken.CData]));
-        Assert.False(TestHelper.Tokenize("<![CDATA[\n", [XmlTokenizer.XmlToken.CData]));
-        Assert.False(TestHelper.Tokenize("<![CDATA[foobar]>", [XmlTokenizer.XmlToken.CData]));
-        Assert.False(TestHelper.Tokenize("<![CDATA[foobar >", [XmlTokenizer.XmlToken.CData]));
-        Assert.False(TestHelper.Tokenize("<![CDATA[ foobar]]", [XmlTokenizer.XmlToken.CData]));
-        Assert.False(TestHelper.Tokenize("<![CDATA[ foobar ", [XmlTokenizer.XmlToken.CData]));
-        Assert.False(TestHelper.Tokenize("<![CDATA[\nfoobar\nhoge\n]>", [XmlTokenizer.XmlToken.CData]));
-        Assert.False(TestHelper.Tokenize("<![CDATA[\nfoobar\nhoge\n ]]", [XmlTokenizer.XmlToken.CData]));
-        Assert.False(TestHelper.Tokenize("<![CDATA[ \nfoobar\nhoge\n] >", [XmlTokenizer.XmlToken.CData]));
-        Assert.False(TestHelper.Tokenize("<![CDATA[ \nfoobar\nhoge\n ", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.FailTokenize("<![CDATA[]>", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.FailTokenize("<![CDATA[ ]]", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.FailTokenize("<![CDATA[\n", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.FailTokenize("<![CDATA[foobar]>", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.FailTokenize("<![CDATA[foobar >", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.FailTokenize("<![CDATA[ foobar]]", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.FailTokenize("<![CDATA[ foobar ", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.FailTokenize("<![CDATA[\nfoobar\nhoge\n]>", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.FailTokenize("<![CDATA[\nfoobar\nhoge\n ]]", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.FailTokenize("<![CDATA[ \nfoobar\nhoge\n] >", [XmlTokenizer.XmlToken.CData]));
+        Assert.False(TestHelper.FailTokenize("<![CDATA[ \nfoobar\nhoge\n ", [XmlTokenizer.XmlToken.CData]));
     }
 
     [Fact]
     public void NegativeTestElementNoAttributes()
     {
-        Assert.False(TestHelper.Tokenize("<element/", [XmlTokenizer.XmlToken.ElementEmpty]));
-        Assert.False(TestHelper.Tokenize("<element ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element\n", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element\n /", [XmlTokenizer.XmlToken.ElementEmpty]));
+        Assert.False(TestHelper.FailTokenize("<element/", [XmlTokenizer.XmlToken.ElementEmpty]));
+        Assert.False(TestHelper.FailTokenize("<element ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element\n", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element\n /", [XmlTokenizer.XmlToken.ElementEmpty]));
 
-        Assert.False(TestHelper.Tokenize("<element", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element\n", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element\n ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element\n", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element\n ", [XmlTokenizer.XmlToken.ElementStart]));
 
-        Assert.False(TestHelper.Tokenize("</element", [XmlTokenizer.XmlToken.ElementEnd]));
-        Assert.False(TestHelper.Tokenize("</element ", [XmlTokenizer.XmlToken.ElementEnd]));
-        Assert.False(TestHelper.Tokenize("</element\n", [XmlTokenizer.XmlToken.ElementEnd]));
-        Assert.False(TestHelper.Tokenize("</element\n ", [XmlTokenizer.XmlToken.ElementEnd]));
+        Assert.False(TestHelper.FailTokenize("</element", [XmlTokenizer.XmlToken.ElementEnd]));
+        Assert.False(TestHelper.FailTokenize("</element ", [XmlTokenizer.XmlToken.ElementEnd]));
+        Assert.False(TestHelper.FailTokenize("</element\n", [XmlTokenizer.XmlToken.ElementEnd]));
+        Assert.False(TestHelper.FailTokenize("</element\n ", [XmlTokenizer.XmlToken.ElementEnd]));
 
-        Assert.False(TestHelper.Tokenize("<el:em_en-t/", [XmlTokenizer.XmlToken.ElementEmpty]));
-        Assert.False(TestHelper.Tokenize("<el:em_en-t ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<el:em_en-t\n/", [XmlTokenizer.XmlToken.ElementEmpty]));
-        Assert.False(TestHelper.Tokenize("<el:em_en-t\n ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<el:em_en-t/", [XmlTokenizer.XmlToken.ElementEmpty]));
+        Assert.False(TestHelper.FailTokenize("<el:em_en-t ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<el:em_en-t\n/", [XmlTokenizer.XmlToken.ElementEmpty]));
+        Assert.False(TestHelper.FailTokenize("<el:em_en-t\n ", [XmlTokenizer.XmlToken.ElementStart]));
 
-        Assert.False(TestHelper.Tokenize("<el:em_en-t", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<el:em_en-t ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<el:em_en-t\n", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<el:em_en-t\n ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<el:em_en-t", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<el:em_en-t ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<el:em_en-t\n", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<el:em_en-t\n ", [XmlTokenizer.XmlToken.ElementStart]));
 
-        Assert.False(TestHelper.Tokenize("</el:em_en-t", [XmlTokenizer.XmlToken.ElementEnd]));
+        Assert.False(TestHelper.FailTokenize("</el:em_en-t", [XmlTokenizer.XmlToken.ElementEnd]));
     }
 
     [Fact]
     public void NegativeTestElementWithAttributes()
     {
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\"/", [XmlTokenizer.XmlToken.ElementEmpty]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\" ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" /", [XmlTokenizer.XmlToken.ElementEmpty]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\"/", [XmlTokenizer.XmlToken.ElementEmpty]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\" ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" /", [XmlTokenizer.XmlToken.ElementEmpty]));
 
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\" xyz=\"abc\"/", [XmlTokenizer.XmlToken.ElementEmpty]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\" xyz=\"abc\" ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n/", [XmlTokenizer.XmlToken.ElementEmpty]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\" xyz=\"abc\"/", [XmlTokenizer.XmlToken.ElementEmpty]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\" xyz=\"abc\" ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n/", [XmlTokenizer.XmlToken.ElementEmpty]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n ", [XmlTokenizer.XmlToken.ElementStart]));
 
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\" xyz=\"abc\" standalone /", [XmlTokenizer.XmlToken.ElementEmpty]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\" xyz=\"abc\" standalone ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n/", [XmlTokenizer.XmlToken.ElementEmpty]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\" xyz=\"abc\" standalone /", [XmlTokenizer.XmlToken.ElementEmpty]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\" xyz=\"abc\" standalone ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n/", [XmlTokenizer.XmlToken.ElementEmpty]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n ", [XmlTokenizer.XmlToken.ElementStart]));
 
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\"   xyz=\"abc\"/", [XmlTokenizer.XmlToken.ElementEmpty]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n/", [XmlTokenizer.XmlToken.ElementEmpty]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\"   xyz=\"abc\"/", [XmlTokenizer.XmlToken.ElementEmpty]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n/", [XmlTokenizer.XmlToken.ElementEmpty]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n ", [XmlTokenizer.XmlToken.ElementStart]));
 
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone/", [XmlTokenizer.XmlToken.ElementEmpty]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone/", [XmlTokenizer.XmlToken.ElementEmpty]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone ", [XmlTokenizer.XmlToken.ElementStart]));
         // commented out b/c `<element / >` does not actually fail as expected
         // this is a bug in the tokenizer
         //Assert.False(
-        //    TestHelper.Tokenize(
+        //    TestHelper.FailTokenize(
         //        "<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n/ >",
         //        [XmlTokenizer.XmlToken.ElementStart]
         //    )
         //);
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n ", [XmlTokenizer.XmlToken.ElementStart]));
 
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\"", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\" ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\"", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\"", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\" ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\"", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" ", [XmlTokenizer.XmlToken.ElementStart]));
 
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\" xyz=\"abc\"", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\" xyz=\"abc\" ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" \n", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\" xyz=\"abc\"", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\" xyz=\"abc\" ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" \n", [XmlTokenizer.XmlToken.ElementStart]));
 
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone \n", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone \n", [XmlTokenizer.XmlToken.ElementStart]));
 
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\"   xyz=\"abc\"", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" \n", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\"   xyz=\"abc\"", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\"\n", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" \n", [XmlTokenizer.XmlToken.ElementStart]));
 
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone ", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n", [XmlTokenizer.XmlToken.ElementStart]));
-        Assert.False(TestHelper.Tokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone \n", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"hogehoge\"   xyz=\"abc\" standalone ", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone\n", [XmlTokenizer.XmlToken.ElementStart]));
+        Assert.False(TestHelper.FailTokenize("<element foobar=\"{hogehoge}\" xyz=\"abc\" standalone \n", [XmlTokenizer.XmlToken.ElementStart]));
     }
 
     [Fact]
     public void NegativeTestContent()
     {
-        Assert.False(TestHelper.Tokenize("1 < 2", [XmlTokenizer.XmlToken.Content]));
+        Assert.False(TestHelper.FailTokenize("1 < 2", [XmlTokenizer.XmlToken.Content]));
     }
 }

--- a/Tests/SAX.Tokenizer.Test/TestHelper.cs
+++ b/Tests/SAX.Tokenizer.Test/TestHelper.cs
@@ -74,4 +74,67 @@ public static class TestHelper
             return false;
         }
     }
+
+    public static bool FailTokenize(string input, XmlTokenizer.XmlToken[] expectedTypes)
+    {
+        Assert.NotNull(input);
+        Assert.NotEmpty(input);
+
+        Assert.ThrowsAny<Superpower.ParseException>(() =>
+        {
+            XmlTokenizer.Instance.Tokenize(input);
+        });
+
+        try
+        {
+            var tokens = XmlTokenizer.Instance.Tokenize(input);
+            Assert.Equal(expectedTypes.Length, tokens.Count());
+            for (int i = 0; i < expectedTypes.Length; i++)
+            {
+                var token = tokens.ElementAt(i);
+                Assert.True(token.HasValue);
+                Assert.Equal(expectedTypes[i], token.Kind);
+                Console.WriteLine($"{token.Span.Position.Line}:{token.Span.Position.Column} {token.Kind} '{token.Span.ToStringValue()}'");
+            }
+
+            return expectedTypes.Length == tokens.Count();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"exception: {ex}");
+            return false;
+        }
+    }
+
+    public static bool FailTokenize(string input, TokenTypeAndValue[] expectedTokens)
+    {
+        Assert.NotNull(input);
+        Assert.NotEmpty(input);
+
+        Assert.ThrowsAny<Superpower.ParseException>(() =>
+        {
+            XmlTokenizer.Instance.Tokenize(input);
+        });
+
+        try
+        {
+            var tokens = XmlTokenizer.Instance.Tokenize(input);
+            Assert.Equal(expectedTokens.Length, tokens.Count());
+            for (int i = 0; i < expectedTokens.Length; i++)
+            {
+                var token = tokens.ElementAt(i);
+                Assert.True(token.HasValue);
+                Assert.Equal(expectedTokens[i].Token, token.Kind);
+                Assert.Equal(expectedTokens[i].Value, token.Span.ToStringValue());
+                Console.WriteLine($"{token.Span.Position.Line}:{token.Span.Position.Column} {token.Kind} '{token.Span.ToStringValue()}'");
+            }
+
+            return expectedTokens.Length == tokens.Count();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"exception: {ex}");
+            return false;
+        }
+    }
 }

--- a/Tests/SAX.Tokenizer.Test/TestHelper.cs
+++ b/Tests/SAX.Tokenizer.Test/TestHelper.cs
@@ -7,6 +7,15 @@ public static class TestHelper
         Assert.NotNull(input);
         Assert.NotEmpty(input);
 
+        Assert.NotRaisedAny(
+            _ => { },
+            _ => { },
+            () =>
+            {
+                XmlTokenizer.Instance.Tokenize(input);
+            }
+        );
+
         try
         {
             var tokens = XmlTokenizer.Instance.Tokenize(input);
@@ -34,6 +43,15 @@ public static class TestHelper
     {
         Assert.NotNull(input);
         Assert.NotEmpty(input);
+
+        Assert.NotRaisedAny(
+            _ => { },
+            _ => { },
+            () =>
+            {
+                XmlTokenizer.Instance.Tokenize(input);
+            }
+        );
 
         try
         {


### PR DESCRIPTION
- **feat: assert that Tokenizer does not throw any exception in TestHelper.Tokenize()**
- **feat: implement TestHelper.FailTokenize() to assert that Tokenizer does throw an exception**
- **refactor: call TestHelper.FailTokenize() in Negative Tokenizer tests**
