### PR TITLE
refactor: change newline conserving in FormattingXmlReadHandler

### DIFF
--- a/Tests/XmlFormat.Test.Assets/idtest.xml
+++ b/Tests/XmlFormat.Test.Assets/idtest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
+
 <!-- main window -->
 <Window
   xmlns="https://github.com/avaloniaui"

--- a/XmlFormat.Lib/FormattingXmlReadHandler.cs
+++ b/XmlFormat.Lib/FormattingXmlReadHandler.cs
@@ -100,6 +100,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         }
 
         textWriter.WriteLineNoTabs(" ?>");
+        textWriter.WriteLineNoTabs();
         textWriter.Flush();
     }
 


### PR DESCRIPTION
- **fix: always keep 1 empty line after Xml Declaration**
- **fix: keep at most 2 newlines after text**
- **fix: adapt idtest.xml resource to have newline after Xml Declaration**
