### PR TITLE
refactor: set XmlFormat.Lib TargetFramework to netstandard2.0

### DIFF
--- a/XmlFormat.Lib/FormattingXmlReadHandler.cs
+++ b/XmlFormat.Lib/FormattingXmlReadHandler.cs
@@ -86,17 +86,17 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
 
         if (!version.IsEmpty)
         {
-            textWriter.WriteNoTabs(@$" version=""{version}""");
+            textWriter.WriteNoTabs(@$" version=""{version.ToString()}""");
         }
 
         if (!encoding.IsEmpty)
         {
-            textWriter.WriteNoTabs(@$" encoding=""{encoding}""");
+            textWriter.WriteNoTabs(@$" encoding=""{encoding.ToString()}""");
         }
 
         if (!standalone.IsEmpty)
         {
-            textWriter.WriteNoTabs(@$" standalone=""{standalone}""");
+            textWriter.WriteNoTabs(@$" standalone=""{standalone.ToString()}""");
         }
 
         textWriter.WriteLineNoTabs(" ?>");
@@ -105,13 +105,13 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
 
     public override void OnProcessingInstruction(ReadOnlySpan<char> identifier, ReadOnlySpan<char> contents, int line, int column)
     {
-        textWriter.WriteLine(@$"<?{identifier}{contents}?>");
+        textWriter.WriteLine(@$"<?{identifier.ToString()}{contents.ToString()}?>");
         textWriter.Flush();
     }
 
     public virtual void OnElementOpen(ReadOnlySpan<char> name, int line, int column)
     {
-        textWriter.Write($"<{name}");
+        textWriter.Write($"<{name.ToString()}");
         textWriter.Flush();
         textWriter.Indent++;
     }
@@ -126,16 +126,16 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         if (multiline)
         {
             if (value.IsEmpty)
-                textWriter.WriteLine(@$"{name}");
+                textWriter.WriteLine(@$"{name.ToString()}");
             else
-                textWriter.WriteLine(@$"{name}=""{value}""");
+                textWriter.WriteLine(@$"{name.ToString()}=""{value.ToString()}""");
         }
         else
         {
             if (value.IsEmpty)
-                textWriter.Write(@$" {name}");
+                textWriter.Write(@$" {name.ToString()}");
             else
-                textWriter.Write(@$" {name}=""{value}""");
+                textWriter.Write(@$" {name.ToString()}=""{value.ToString()}""");
         }
     }
 
@@ -196,7 +196,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
     public override void OnElementEnd(ReadOnlySpan<char> name, int line, int column)
     {
         textWriter.Indent--;
-        textWriter.WriteLine($"</{name}>");
+        textWriter.WriteLine($"</{name.ToString()}>");
         textWriter.Flush();
     }
 
@@ -237,7 +237,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         for (int i = 0; i < Math.Min(leadingNewlines - 1, Options.MaxEmptyLines); i++)
             textWriter.WriteLineNoTabs();
 
-        textWriter.WriteLine(trimText.Trim());
+        textWriter.WriteLine(trimText.Trim().ToString());
 
         // eat trailing newlines
         // note: due to textWriter.WriteLine() above, we have to discount 1 trailing newline
@@ -251,13 +251,13 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
     {
         if (comment.Length < Options.LineLength)
         {
-            textWriter.WriteLine($"<!-- {comment.Trim()} -->");
+            textWriter.WriteLine($"<!-- {comment.Trim().ToString()} -->");
         }
         else
         {
             textWriter.WriteLine("<!--");
             textWriter.Indent++;
-            textWriter.WriteLine(comment.Trim());
+            textWriter.WriteLine(comment.Trim().ToString());
             textWriter.Indent--;
             textWriter.WriteLine("-->");
         }
@@ -267,7 +267,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
     public override void OnCData(ReadOnlySpan<char> cdata, int line, int column)
     {
         textWriter.WriteLine("<![CDATA[");
-        textWriter.WriteLineNoTabs($"{cdata.Trim('\n').TrimEnd()}");
+        textWriter.WriteLineNoTabs($"{cdata.Trim('\n').TrimEnd().ToString()}");
         textWriter.WriteTabs();
         textWriter.WriteLine("]]>");
         textWriter.Flush();

--- a/XmlFormat.Lib/FormattingXmlReadHandler.cs
+++ b/XmlFormat.Lib/FormattingXmlReadHandler.cs
@@ -152,7 +152,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
             currentAttributes.Sort(Attribute.Compare);
             foreach (var attribute in currentAttributes)
             {
-                OnWriteElementAttribute(multiline: multiline, name: attribute.Name, value: attribute.Value);
+                OnWriteElementAttribute(multiline: multiline, name: attribute.Name.AsSpan(), value: attribute.Value.AsSpan());
             }
 
             currentAttributes = null;
@@ -182,7 +182,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
             currentAttributes.Sort(Attribute.Compare);
             foreach (var attribute in currentAttributes)
             {
-                OnWriteElementAttribute(multiline: multiline, name: attribute.Name, value: attribute.Value);
+                OnWriteElementAttribute(multiline: multiline, name: attribute.Name.AsSpan(), value: attribute.Value.AsSpan());
             }
 
             currentAttributes = null;

--- a/XmlFormat.Lib/ReadOnlySpanExtension.cs
+++ b/XmlFormat.Lib/ReadOnlySpanExtension.cs
@@ -13,7 +13,7 @@ public static class ReadOnlySpanCharExtensions
     public static ReadOnlySpan<char> Trim(this ReadOnlySpan<char> span, Func<char, bool> match)
     {
         // Assume that in most cases input doesn't need trimming
-        if (span.Length == 0 || (!match(span[0]) && !match(span[^1])))
+        if (span.Length == 0 || (!match(span[0]) && !match(span[span.Length - 1])))
         {
             return span;
         }

--- a/XmlFormat.Lib/System.Runtime.CompilerServices.IsExternalInit.cs
+++ b/XmlFormat.Lib/System.Runtime.CompilerServices.IsExternalInit.cs
@@ -1,0 +1,3 @@
+namespace System.Runtime.CompilerServices;
+
+public class IsExternalInit { }

--- a/XmlFormat.Lib/XmlFormat.Lib.csproj
+++ b/XmlFormat.Lib/XmlFormat.Lib.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>

--- a/XmlFormat.Lib/XmlFormat.Lib.csproj
+++ b/XmlFormat.Lib/XmlFormat.Lib.csproj
@@ -17,6 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Memory" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\XmlFormat.SAX\XmlFormat.SAX.csproj" />
   </ItemGroup>
 

--- a/XmlFormat.Lib/XmlReadHandlerBase.cs
+++ b/XmlFormat.Lib/XmlReadHandlerBase.cs
@@ -39,27 +39,27 @@ public class XmlReadHandlerBase : IXMLEventHandler, IDisposable
         ReadOnlySpan<char> standalone,
         int line,
         int column
-    ) => writer.WriteLine($"Xml({line}:{column}): {version} {encoding} {standalone}");
+    ) => writer.WriteLine($"Xml({line}:{column}): {version.ToString()} {encoding.ToString()} {standalone.ToString()}");
 
     public virtual void OnProcessingInstruction(ReadOnlySpan<char> identifier, ReadOnlySpan<char> contents, int line, int column) =>
-        writer.WriteLine($"PI({line}:{column}): {identifier} {contents}");
+        writer.WriteLine($"PI({line}:{column}): {identifier.ToString()} {contents.ToString()}");
 
     public virtual void OnElementStartOpen(ReadOnlySpan<char> name, int line, int column) =>
-        writer.WriteLine($"ElementStart open({line}:{column}): {name}");
+        writer.WriteLine($"ElementStart open({line}:{column}): {name.ToString()}");
 
     public virtual void OnElementStartClose(ReadOnlySpan<char> name, int line, int column) =>
-        writer.WriteLine($"ElementStart close({line}:{column}): {name}");
+        writer.WriteLine($"ElementStart close({line}:{column}): {name.ToString()}");
 
     public virtual void OnElementEmptyOpen(ReadOnlySpan<char> name, int line, int column) =>
-        writer.WriteLine($"ElementEmpty open({line}:{column}): {name}");
+        writer.WriteLine($"ElementEmpty open({line}:{column}): {name.ToString()}");
 
     public virtual void OnElementEmptyClose(ReadOnlySpan<char> name, int line, int column) =>
-        writer.WriteLine($"ElementEmpty close({line}:{column}): {name}");
+        writer.WriteLine($"ElementEmpty close({line}:{column}): {name.ToString()}");
 
     //public virtual void OnEndTagEmpty() => writer.WriteLine($"EndTagEmpty");
 
     public virtual void OnElementEnd(ReadOnlySpan<char> name, int line, int column) =>
-        writer.WriteLine($"ElementEnd({line}:{column}): {name}");
+        writer.WriteLine($"ElementEnd({line}:{column}): {name.ToString()}");
 
     public virtual void OnAttribute(
         ReadOnlySpan<char> name,
@@ -68,14 +68,16 @@ public class XmlReadHandlerBase : IXMLEventHandler, IDisposable
         int nameColumn,
         int valueLine,
         int valueColumn
-    ) => writer.WriteLine($"Attribute({nameLine}:{nameColumn})-({valueLine}:{valueColumn}): {name}=\"{value}\"");
+    ) => writer.WriteLine($"Attribute({nameLine}:{nameColumn})-({valueLine}:{valueColumn}): {name.ToString()}=\"{value.ToString()}\"");
 
-    public virtual void OnText(ReadOnlySpan<char> text, int line, int column) => writer.WriteLine($"Content({line}:{column}): {text}");
+    public virtual void OnText(ReadOnlySpan<char> text, int line, int column) =>
+        writer.WriteLine($"Content({line}:{column}): {text.ToString()}");
 
     public virtual void OnComment(ReadOnlySpan<char> comment, int line, int column) =>
-        writer.WriteLine($"Comment({line}:{column}): {comment}");
+        writer.WriteLine($"Comment({line}:{column}): {comment.ToString()}");
 
-    public virtual void OnCData(ReadOnlySpan<char> cdata, int line, int column) => writer.WriteLine($"CDATA({line}:{column}): {cdata}");
+    public virtual void OnCData(ReadOnlySpan<char> cdata, int line, int column) =>
+        writer.WriteLine($"CDATA({line}:{column}): {cdata.ToString()}");
 
     public virtual void OnError(string message, int line, int column) => Console.Error.WriteLine($"ERROR({line}:{column}): {message}");
 

--- a/XmlFormat.Lib/XmlReadHandlerBase.cs
+++ b/XmlFormat.Lib/XmlReadHandlerBase.cs
@@ -9,7 +9,7 @@ public class XmlReadHandlerBase : IXMLEventHandler, IDisposable
     protected readonly StreamWriter writer;
 
     public XmlReadHandlerBase(Stream stream, Encoding encoding)
-        : this(new StreamWriter(stream, encoding, leaveOpen: true) { AutoFlush = true, }) { }
+        : this(new StreamWriter(stream, encoding, bufferSize: 4096, leaveOpen: true) { AutoFlush = true, }) { }
 
     public XmlReadHandlerBase(StreamWriter streamWriter)
     {


### PR DESCRIPTION
- **build: set Target Framework to netstandard2.0 for XmlFormat.Lib project**
- **build: add package dependency on System.Memory to XmlFormat.Lib project**
- **fix: explicitly call ReadOnlySpan<char>.ToString() for each instance in XmlReadHandlerBase**
- **fix: explicitly call ReadOnlySpan<char>.ToString() for each instance in FormattingXmlReadHandler**
- **fix: explicitly call string.AsSpan() in FormattingXmlReadHandler**
- **fix: pass bufferSize to StreamWriter.ctor() in XmlReadHandlerBase**
- **fix: fix access on last element in ReadOnlySpan<char>.Trim(predicate) extension method**
- **fix: implement dummy class `System.Runtime.CompilerServices.IsExternalInit`**
