### PR TITLE
feat: add option `--format` to XmlFormat.Tool to override formatting options

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.5" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.5" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.5" />
     <PackageVersion Include="Alexinea.Extensions.Configuration.Toml" Version="7.0.0" />
   </ItemGroup>
 

--- a/XmlFormat.Tool/Program.cs
+++ b/XmlFormat.Tool/Program.cs
@@ -16,6 +16,15 @@ public class Program
         [Option('p', "profile", Required = false, HelpText = "Specify the XML formatting profile to use instead of the file extension.")]
         public string? Profile { get; set; } = default;
 
+        [Option(
+            'f',
+            "format",
+            Required = false,
+            Separator = ';',
+            HelpText = "Specify formatting options to override the configuration. Use ';' as separator."
+        )]
+        public IEnumerable<string>? FormattingOptions { get; set; } = default;
+
         [Value(0, MetaName = "inputs", HelpText = "Input files.")]
         public IEnumerable<string>? InputFiles { get; set; } = default;
     }
@@ -33,6 +42,7 @@ public class Program
         IConfiguration config = new ConfigurationBuilder()
             .AddTomlFile(Path.Join(AppDomain.CurrentDomain.BaseDirectory, "xmlformat.toml"), optional: false, reloadOnChange: true)
             .AddTomlFile(Path.Join(Environment.CurrentDirectory, ".xmlformat"), optional: true, reloadOnChange: true)
+            .AddCommandLine(options.FormattingOptions?.ToArray() ?? [])
             .Build();
 
         Console.WriteLine($"options.Inline: {options.Inline}");

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
     <PackageReference Include="CommandLineParser" />
   </ItemGroup>


### PR DESCRIPTION
- **build: add package reference to Microsoft.Extensions.Configuration.CommandLine v9.0.5**
- **feat: add option `--format` to XmlFormat.Tool to override formatting options**
