### PR TITLE
refactor: implement inline task to replace exec task for formatting input files with XmlFormat.Tool

### DIFF
--- a/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
+++ b/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
@@ -145,6 +145,78 @@
     </Task>
   </UsingTask>
 
+  <UsingTask
+    TaskName="XmlFormatFiles"
+    TaskFactory="CodeTaskFactory"
+    AssemblyFile="$(MsBuildAssembly)"
+  >
+    <Task>
+      <ParameterGroup>
+        <LineLength ParameterType="System.Int32" Required="false" />
+        <Tabs ParameterType="System.String" Required="false" />
+        <TabsRepeat ParameterType="System.Int32" Required="false" />
+        <MaxEmptyLines ParameterType="System.Int32" Required="false" />
+        <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      </ParameterGroup>
+
+      <Using Namespace="System" />
+      <Using Namespace="System.Diagnostics" />
+      <Using Namespace="System.Linq" />
+      <Code Type="Fragment" Language="cs">
+      <![CDATA[
+        Log.LogMessage(MessageImportance.High, "Formatting: Running `xf`");
+
+        string formatParam = string.Empty;
+
+        if (LineLength is not null)
+        {
+          formatParam = $"/LineLength={LineLength}";
+        }
+
+        if (Tabs is not null)
+        {
+          formatParam += (string.IsNullOrEmpty(formatParam) ? "" : ";");
+          formatParam += $"/Tabs='{Tabs}'";
+        }
+
+        if (TabsRepeat is not null)
+        {
+          formatParam += (string.IsNullOrEmpty(formatParam) ? "" : ";");
+          formatParam += $"/TabsRepeat={TabsRepeat}";
+        }
+
+        if (MaxEmptyLines is not null)
+        {
+          formatParam += (string.IsNullOrEmpty(formatParam) ? "" : ";");
+          formatParam += $"/MaxEmptyLines={MaxEmptyLines}";
+        }
+
+        string files = string.Join(' ', Files.Select(f => f.ItemSpec));
+        string arguments = $"--inline --format \"{formatParam}\" {files}"
+        Log.LogMessage(MessageImportance.High, "Formatting: Running `xf {arguments}`");
+
+        Process process = new Process();
+        process.StartInfo = new ProcessStartInfo()
+        {
+            FileName = "xf",
+            Arguments = arguments,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        process.Start();
+
+        string output = process.StandardOutput.ReadToEnd();
+        Console.WriteLine(output);
+
+        process.WaitForExit();
+      ]]>
+      </Code>
+    </Task>
+  </UsingTask>
+
+
   <Target Name="FormatXmlFiles"
           BeforeTargets="CoreCompile"
           Condition="'$(XmlFormatEnable)' == 'true' AND @(XmlFormatFile->Count()) > 0">

--- a/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
+++ b/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
@@ -29,23 +29,6 @@
     <XmlFormatMaxEmptyLines Condition="'$(XmlFormatMaxEmptyLines)' == ''">1</XmlFormatMaxEmptyLines>
   </PropertyGroup>
 
-  <!-- setup parameters -->
-  <PropertyGroup Condition="'$(XmlFormatLineLength)' != ''">
-    <XmlFormatConfig>/LineLength=$(XmlFormatLineLength)</XmlFormatConfig>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(XmlFormatTabs)' != ''">
-    <XmlFormatConfig>$(XmlFormatConfig);/Tabs=$(XmlFormatTabs)</XmlFormatConfig>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(XmlFormatTabsRepeat)' != ''">
-    <XmlFormatConfig>$(XmlFormatConfig);/TabsRepeat=$(XmlFormatTabsRepeat)</XmlFormatConfig>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(XmlFormatMaxEmptyLines)' != ''">
-    <XmlFormatConfig>$(XmlFormatConfig);/MaxEmptyLines=$(XmlFormatMaxEmptyLines)</XmlFormatConfig>
-  </PropertyGroup>
-
   <UsingTask
     TaskName="InstallXmlFormatTool"
     TaskFactory="CodeTaskFactory"

--- a/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
+++ b/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
@@ -236,7 +236,13 @@
     <DisplayXmlFormatToolVersion />
 
     <!-- run xf -->
-    <Exec Command="xf --inline --format '$(XmlFormatConfig)' -- %(XmlFormatFile.FullPath)"/>
+    <XmlFormatFiles
+      LineLength="$(XmlFormatLineLength)"
+      Tabs="$(XmlFormatTabs)"
+      TabsRepeat="$(XmlFormatTabsRepeat)"
+      MaxEmptyLines="$(XmlFormatMaxEmptyLines)"
+      Files="@(XmlFormatFile)"
+    />
 
   </Target>
 </Project>


### PR DESCRIPTION
- **feat: implement task XmlFormatFiles to wrap `xf --inline --format '<format>' <files>`**
- **refactor: replace exec task with XmlFormatFiles to format input files**
- **refactor: remove conditional PropertyGroups required to set up property string XmlFormatConfig**
