### PR TITLE
fix: move ParameterGroup element to be direct child of UsingTask for XmlFormatFiles task

### DIFF
--- a/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
+++ b/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
@@ -146,14 +146,15 @@
     TaskFactory="$(TaskFactory)"
     AssemblyFile="$(MsBuildAssembly)"
   >
+    <ParameterGroup>
+      <LineLength ParameterType="System.Int32" Required="false" />
+      <Tabs ParameterType="System.String" Required="false" />
+      <TabsRepeat ParameterType="System.Int32" Required="false" />
+      <MaxEmptyLines ParameterType="System.Int32" Required="false" />
+      <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+    </ParameterGroup>
+
     <Task>
-      <ParameterGroup>
-        <LineLength ParameterType="System.Int32" Required="false" />
-        <Tabs ParameterType="System.String" Required="false" />
-        <TabsRepeat ParameterType="System.Int32" Required="false" />
-        <MaxEmptyLines ParameterType="System.Int32" Required="false" />
-        <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
-      </ParameterGroup>
 
       <Using Namespace="System" />
       <Using Namespace="System.Diagnostics" />


### PR DESCRIPTION
note: fixes error MSB3756: The element <ParameterGroup> is not a valid child of the <Task> element.
      Valid child elements are <Code>, <Reference>, and <Using>.
