### PR TITLE
refactor: rename task XmlFormatFiles -> RunXmlFormatFiles

### DIFF
--- a/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
+++ b/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
@@ -142,7 +142,7 @@
   </UsingTask>
 
   <UsingTask
-    TaskName="XmlFormatFiles"
+    TaskName="RunXmlFormatFiles"
     TaskFactory="$(TaskFactory)"
     AssemblyFile="$(MsBuildAssembly)"
   >
@@ -233,7 +233,7 @@
     <DisplayXmlFormatToolVersion />
 
     <!-- run xf -->
-    <XmlFormatFiles
+    <RunXmlFormatFiles
       LineLength="$(XmlFormatLineLength)"
       Tabs="$(XmlFormatTabs)"
       TabsRepeat="$(XmlFormatTabsRepeat)"


### PR DESCRIPTION
reason: avoid nameclass with target being also called 'FormatXmlFiles'
