### PR TITLE
fix: join item paths using `string.Join(string, IEnumerable<string>)` variant in RunXmlFormatFiles task implementation

### DIFF
--- a/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
+++ b/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
@@ -188,7 +188,7 @@
           formatParam += $"/MaxEmptyLines={MaxEmptyLines}";
         }
 
-        string files = string.Join(' ', Files.Select(f => f.ItemSpec));
+        string files = string.Join(" ", Files.Select(f => f.ItemSpec));
         string arguments = $"--inline --format \"{formatParam}\" {files}";
         Log.LogMessage(MessageImportance.High, "Formatting: Running `xf {arguments}`");
 


### PR DESCRIPTION
reason: `string.Join(string, IEnumerable<string>)` is the matching overload in this case
