### PR TITLE
build: precise TargetFrameworkIdentifier and TargetFrameworkVersion in unit test projects

### DIFF
--- a/Tests/MsBuild.Task.Test/MsBuild.Task.Test.csproj
+++ b/Tests/MsBuild.Task.Test/MsBuild.Task.Test.csproj
@@ -19,6 +19,11 @@
     -->
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>9.0</TargetFrameworkVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/Tests/SAX.EventHandler.Test/SAX.EventHandler.Test.csproj
+++ b/Tests/SAX.EventHandler.Test/SAX.EventHandler.Test.csproj
@@ -21,6 +21,11 @@
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>9.0</TargetFrameworkVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/Tests/SAX.Formatter.Test/SAX.Formatter.Test.csproj
+++ b/Tests/SAX.Formatter.Test/SAX.Formatter.Test.csproj
@@ -21,6 +21,11 @@
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>9.0</TargetFrameworkVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/Tests/SAX.TokenParser.Test/SAX.TokenParser.Test.csproj
+++ b/Tests/SAX.TokenParser.Test/SAX.TokenParser.Test.csproj
@@ -21,6 +21,11 @@
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>9.0</TargetFrameworkVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/Tests/SAX.Tokenizer.Negative.Test/SAX.Tokenizer.Negative.Test.csproj
+++ b/Tests/SAX.Tokenizer.Negative.Test/SAX.Tokenizer.Negative.Test.csproj
@@ -21,6 +21,11 @@
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>9.0</TargetFrameworkVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/Tests/SAX.Tokenizer.Test/SAX.Tokenizer.Test.csproj
+++ b/Tests/SAX.Tokenizer.Test/SAX.Tokenizer.Test.csproj
@@ -22,6 +22,11 @@
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>9.0</TargetFrameworkVersion>
+  </PropertyGroup>
+
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/Tests/XmlFormat.Test.Assets/XmlFormat.Test.Assets.csproj
+++ b/Tests/XmlFormat.Test.Assets/XmlFormat.Test.Assets.csproj
@@ -20,6 +20,11 @@
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
+    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>9.0</TargetFrameworkVersion>
+  </PropertyGroup>
+
   <ItemGroup Label="embeded files">
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)test.xml"/>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)idtest.xml"/>


### PR DESCRIPTION
- **build: precise TargetFrameworkIdentifier and TargetFrameworkVersion in MsBuild.Task.Test unit test project**
- **build: precise TargetFrameworkIdentifier and TargetFrameworkVersion in SAX.EventHandler.Test unit test project**
- **build: precise TargetFrameworkIdentifier and TargetFrameworkVersion in SAX.Formatter.Test unit test project**
- **build: precise TargetFrameworkIdentifier and TargetFrameworkVersion in SAX.TokenParser.Test unit test project**
- **build: precise TargetFrameworkIdentifier and TargetFrameworkVersion in SAX.Tokenizer.Negative.Test unit test project**
- **build: precise TargetFrameworkIdentifier and TargetFrameworkVersion in SAX.Tokenizer.Test unit test project**
- **build: precise TargetFrameworkIdentifier and TargetFrameworkVersion in XmlFormat.Test.Assets unit test project**
