### PR TITLE
refactor: merge RunXmlFormatFiles.Execute...() methods into .Execute()

### DIFF
--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -1,12 +1,12 @@
-using Microsoft.Build.Framework;
-using Microsoft.Build.Utilities;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Diagnostics;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
 
 namespace XmlFormat.MsBuild.Task;
 
@@ -58,6 +58,30 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
     {
         get { return _Success; }
         set { _Success = value; }
+    }
+
+    private int RunCommand(string command, string arguments)
+    {
+        Log.LogMessage(MessageImportance.High, "Formatting: `{} {}`", command, arguments);
+        Process process = new()
+        {
+            StartInfo = new()
+            {
+                FileName = command,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            },
+        };
+
+        process.Start();
+
+        string output = process.StandardOutput.ReadToEnd();
+        Console.WriteLine(output);
+
+        process.WaitForExit();
+        return process.ExitCode;
     }
 
     public bool ExecuteInstallXf()

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -94,24 +94,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
     public bool ExecuteXfHelp()
     {
         Log.LogMessage(MessageImportance.High, "Formatting: Checking `xf` help");
-
-        Process process = new Process();
-        process.StartInfo = new ProcessStartInfo()
-        {
-            FileName = "xf",
-            Arguments = "--help",
-            RedirectStandardOutput = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-
-        process.Start();
-
-        string output = process.StandardOutput.ReadToEnd();
-        Console.WriteLine(output);
-
-        process.WaitForExit();
-        Success = process.ExitCode == 0;
+        Success = RunCommand("xf", "--help") == 0;
         return Success;
     }
 

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -87,24 +87,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
     public bool ExecuteInstallXf()
     {
         Log.LogMessage(MessageImportance.High, "Formatting: Installing `xf`");
-
-        Process process = new Process();
-        process.StartInfo = new ProcessStartInfo()
-        {
-            FileName = "dotnet",
-            Arguments = "tool install -g KageKirin.XmlFormat.Tool",
-            RedirectStandardOutput = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-
-        process.Start();
-
-        string output = process.StandardOutput.ReadToEnd();
-        Console.WriteLine(output);
-
-        process.WaitForExit();
-        Success = process.ExitCode == 0;
+        Success = RunCommand("dotnet", "tool install -g KageKirin.XmlFormat.Tool") == 0;
         return Success;
     }
 

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -137,24 +137,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
         string files = string.Join(" ", Files.Select(f => f.ItemSpec));
         string arguments = $"--inline --format \"{formatParam}\" {files}";
         Log.LogMessage(MessageImportance.High, "Formatting: Running `xf {arguments}`");
-
-        Process process = new Process();
-        process.StartInfo = new ProcessStartInfo()
-        {
-            FileName = "xf",
-            Arguments = arguments,
-            RedirectStandardOutput = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-
-        process.Start();
-
-        string output = process.StandardOutput.ReadToEnd();
-        Console.WriteLine(output);
-
-        process.WaitForExit();
-        Success = process.ExitCode == 0;
+        Success = RunCommand("xf", arguments) == 0;
         return Success;
     }
 

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -101,24 +101,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
     public bool ExecuteXfVersion()
     {
         Log.LogMessage(MessageImportance.High, "Formatting: Checking `xf` version");
-
-        Process process = new Process();
-        process.StartInfo = new ProcessStartInfo()
-        {
-            FileName = "xf",
-            Arguments = "--version",
-            RedirectStandardOutput = true,
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-
-        process.Start();
-
-        string output = process.StandardOutput.ReadToEnd();
-        Console.WriteLine(output);
-
-        process.WaitForExit();
-        Success = process.ExitCode == 0;
+        Success = RunCommand("xf", "--version") == 0;
         return Success;
     }
 


### PR DESCRIPTION
- **feat: implement RunXmlFormatFiles.RunCommand()**
- **refactor: simplify RunXmlFormatFiles.ExecuteInstallXf() to single call to .RunCommand()**
- **refactor: simplify RunXmlFormatFiles.ExecuteXfHelp() to single call to .RunCommand()**
- **refactor: simplify RunXmlFormatFiles.ExecuteXfVersion() to single call to .RunCommand()**
- **refactor: simplify RunXmlFormatFiles.ExecuteXf() to single call to .RunCommand()**
- **refactor: merge RunXmlFormatFiles.Execute...() methods into .Execute()**
