### PR TITLE
refactor: change Option multiples to non-nullable IEnumerable types in XmlFormat.Tool

### DIFF
--- a/XmlFormat.Tool/Program.cs
+++ b/XmlFormat.Tool/Program.cs
@@ -31,6 +31,8 @@ public class Program
 
     public static void Main(string[] args)
     {
+        Console.WriteLine($"running with args: {string.Join(" ", args)}");
+
         CommandLine
             .Parser.Default.ParseArguments<Options>(args) //
             .WithParsed(RunOptions)


### PR DESCRIPTION
- **refactor: change Option.InputFiles to non-nullable IEnumerable**
- **refactor: change Option.FormattingOptions to non-nullable IEnumerable**
- **feat: add debug output of all arguments passed to XmlFormat.Tool**
