### PR TITLE
fix: call `xf` with correct parameters

### DIFF
--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -112,7 +112,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
             formatParam = $"/LineLength={LineLength}";
         }
 
-        if (Tabs is not null)
+        if (!string.IsNullOrEmpty(Tabs))
         {
             formatParam += (string.IsNullOrEmpty(formatParam) ? "" : ";");
             formatParam += $"/Tabs='{Tabs}'";

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -130,8 +130,13 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
             formatParam += $"/MaxEmptyLines={MaxEmptyLines}";
         }
 
+        if (!string.IsNullOrEmpty(formatParam))
+        {
+            formatParam = $"--format \"{formatParam}\"";
+        }
+
         string files = string.Join(" ", Files.Select(f => f.ItemSpec));
-        RunCommand("xf", $"--inline --format \"{formatParam}\" {files}");
+        RunCommand("xf", $"--inline {formatParam} {files}");
         Success = exitCode == 0;
 
         return Success;

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -115,7 +115,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
         if (!string.IsNullOrEmpty(Tabs))
         {
             formatParam += (string.IsNullOrEmpty(formatParam) ? "" : ";");
-            formatParam += $"/Tabs='{Tabs}'";
+            formatParam += $"/Tabs={Tabs}";
         }
 
         if (TabsRepeat > 0)

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -12,7 +12,7 @@ namespace XmlFormat.MsBuild.Task;
 
 public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
 {
-    private int _LineLength;
+    private int _LineLength = 0;
 
     public virtual int LineLength
     {
@@ -20,7 +20,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
         set { _LineLength = value; }
     }
 
-    private string _Tabs;
+    private string _Tabs = string.Empty;
 
     public virtual string Tabs
     {
@@ -28,7 +28,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
         set { _Tabs = value; }
     }
 
-    private int _TabsRepeat;
+    private int _TabsRepeat = 0;
 
     public virtual int TabsRepeat
     {
@@ -36,7 +36,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
         set { _TabsRepeat = value; }
     }
 
-    private int _MaxEmptyLines;
+    private int _MaxEmptyLines = 0;
 
     public virtual int MaxEmptyLines
     {
@@ -44,7 +44,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
         set { _MaxEmptyLines = value; }
     }
 
-    private Microsoft.Build.Framework.ITaskItem[] _Files;
+    private Microsoft.Build.Framework.ITaskItem[] _Files = [];
 
     public virtual Microsoft.Build.Framework.ITaskItem[] Files
     {


### PR DESCRIPTION
- **refactor: set default values to RunXmlFormatFiles properties**
- **fix: improve condition for setting /Tabs format parameter**
- **fix: set /Tabs parameter without any high commas**
- **fix: pass `--format` only of any format parameters have been set in RunXmlFormatFiles**
