### PR TITLE
refactor: simplify RunXmlFormatFiles properties with direct getters/setters

### DIFF
--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -12,6 +12,7 @@ namespace XmlFormat.MsBuild.Task;
 
 public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
 {
+    [Required]
     public virtual string AssemblyFile { get; set; } = string.Empty;
 
     public virtual int LineLength { get; set; } = 0;

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -14,13 +14,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
 {
     public virtual string AssemblyFile { get; set; } = string.Empty;
 
-    private int _LineLength = 0;
-
-    public virtual int LineLength
-    {
-        get { return _LineLength; }
-        set { _LineLength = value; }
-    }
+    public virtual int LineLength { get; set; } = 0;
 
     private string _Tabs = string.Empty;
 

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -16,13 +16,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
 
     public virtual int LineLength { get; set; } = 0;
 
-    private string _Tabs = string.Empty;
-
-    public virtual string Tabs
-    {
-        get { return _Tabs; }
-        set { _Tabs = value; }
-    }
+    public virtual string Tabs { get; set; } = string.Empty;
 
     private int _TabsRepeat = 0;
 

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -12,13 +12,7 @@ namespace XmlFormat.MsBuild.Task;
 
 public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
 {
-    private string _AssemblyFile;
-
-    public virtual string AssemblyFile
-    {
-        get { return _AssemblyFile; }
-        set { _AssemblyFile = value; }
-    }
+    public virtual string AssemblyFile { get; set; } = string.Empty;
 
     private int _LineLength = 0;
 

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -18,13 +18,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
 
     public virtual string Tabs { get; set; } = string.Empty;
 
-    private int _TabsRepeat = 0;
-
-    public virtual int TabsRepeat
-    {
-        get { return _TabsRepeat; }
-        set { _TabsRepeat = value; }
-    }
+    public virtual int TabsRepeat { get; set; } = 0;
 
     private int _MaxEmptyLines = 0;
 

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -23,6 +23,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
 
     public virtual int MaxEmptyLines { get; set; } = 0;
 
+    [Required]
     public virtual Microsoft.Build.Framework.ITaskItem[] Files { get; set; } = [];
 
     public virtual bool Success { get; set; } = true;

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -20,13 +20,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
 
     public virtual int TabsRepeat { get; set; } = 0;
 
-    private int _MaxEmptyLines = 0;
-
-    public virtual int MaxEmptyLines
-    {
-        get { return _MaxEmptyLines; }
-        set { _MaxEmptyLines = value; }
-    }
+    public virtual int MaxEmptyLines { get; set; } = 0;
 
     private Microsoft.Build.Framework.ITaskItem[] _Files = [];
 

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -24,13 +24,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
 
     public virtual Microsoft.Build.Framework.ITaskItem[] Files { get; set; } = [];
 
-    private bool _Success = true;
-
-    public virtual bool Success
-    {
-        get { return _Success; }
-        set { _Success = value; }
-    }
+    public virtual bool Success { get; set; } = true;
 
     private int RunCommand(string command, string arguments)
     {

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -22,13 +22,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
 
     public virtual int MaxEmptyLines { get; set; } = 0;
 
-    private Microsoft.Build.Framework.ITaskItem[] _Files = [];
-
-    public virtual Microsoft.Build.Framework.ITaskItem[] Files
-    {
-        get { return _Files; }
-        set { _Files = value; }
-    }
+    public virtual Microsoft.Build.Framework.ITaskItem[] Files { get; set; } = [];
 
     private bool _Success = true;
 


### PR DESCRIPTION
- **refactor: simplify property RunXmlFormatFiles.AssemblyFile with direct getter/setter**
- **refactor: simplify property RunXmlFormatFiles.LineLength with direct getter/setter**
- **refactor: simplify property RunXmlFormatFiles.Tabs with direct getter/setter**
- **refactor: simplify property RunXmlFormatFiles.TabsRepeat with direct getter/setter**
- **refactor: simplify property RunXmlFormatFiles.MaxEmptyLines with direct getter/setter**
- **refactor: simplify property RunXmlFormatFiles.Files with direct getter/setter**
- **refactor: simplify property RunXmlFormatFiles.Success with direct getter/setter**
- **refactor: mark property RunXmlFormatFiles.AssemblyFile as required**
- **refactor: mark property RunXmlFormatFiles.Files as required**
