### PR TITLE
refactor: read RunXmlFormatFiles Formatting Options through in-memory configuration

### DIFF
--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Text;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Memory;
 
 namespace XmlFormat.MsBuild.Task;
 
@@ -27,27 +29,35 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
 
     private FormattingOptions ReadOptions()
     {
-        FormattingOptions formattingOptions = new();
+        Dictionary<string, string?> memoryOptions = [];
 
         if (LineLength > 0)
         {
-            formattingOptions = formattingOptions with { LineLength = LineLength };
+            memoryOptions["lineLength"] = LineLength.ToString();
         }
 
         if (!string.IsNullOrEmpty(Tabs))
         {
-            formattingOptions = formattingOptions with { Tabs = Tabs };
+            memoryOptions["tabs"] = Tabs;
         }
 
         if (TabsRepeat > 0)
         {
-            formattingOptions = formattingOptions with { TabsRepeat = TabsRepeat };
+            memoryOptions["tabsRepeat"] = TabsRepeat.ToString();
         }
 
         if (MaxEmptyLines > 0)
         {
-            formattingOptions = formattingOptions with { MaxEmptyLines = MaxEmptyLines };
+            memoryOptions["maxEmptyLines"] = MaxEmptyLines.ToString();
         }
+
+        ConfigurationBuilder configBuilder = new();
+        configBuilder.AddInMemoryCollection(memoryOptions);
+
+        IConfiguration config = configBuilder.Build();
+
+        FormattingOptions formattingOptions = new();
+        config.Bind(formattingOptions);
 
         return formattingOptions;
     }
@@ -55,7 +65,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
     public override bool Execute()
     {
         FormattingOptions formattingOptions = ReadOptions();
-        Log.LogMessage($"Formatting with options: {formattingOptions}");
+        Log.LogMessage("Formatting with options: {}", formattingOptions);
 
         foreach (string fileName in Files.Select(item => item.ItemSpec))
         {

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -25,7 +25,7 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
 
     public virtual bool Success { get; set; } = true;
 
-    public override bool Execute()
+    private FormattingOptions ReadOptions()
     {
         FormattingOptions formattingOptions = new();
 
@@ -49,6 +49,12 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
             formattingOptions = formattingOptions with { MaxEmptyLines = MaxEmptyLines };
         }
 
+        return formattingOptions;
+    }
+
+    public override bool Execute()
+    {
+        FormattingOptions formattingOptions = ReadOptions();
         Log.LogMessage($"Formatting with options: {formattingOptions}");
 
         foreach (string fileName in Files.Select(item => item.ItemSpec))

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -68,6 +68,7 @@
 
   <ItemGroup Label="package references">
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
   </ItemGroup>
 
   <ItemGroup Label="project references">

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -70,6 +70,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
   </ItemGroup>
 
   <ItemGroup Label="project references">

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -69,6 +69,7 @@
   <ItemGroup Label="package references">
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
   </ItemGroup>
 
   <ItemGroup Label="project references">


### PR DESCRIPTION
- **build: add package reference to Microsoft.Extensions.Configuration**
- **build: add package reference to Microsoft.Extensions.Configuration.Abstractions**
- **build: add package reference to Microsoft.Extensions.Configuration.Binder**
- **refactor: move FormattingOptions creation into RunXmlFormatFiles.ReadOptions()**
- **refactor: read FormattingOptions through in-memory configuration in RunXmlFormatFiles.ReadOptions()**
