### PR TITLE
feat: read RunXmlFormatFiles Formatting Options from local configuration files

### DIFF
--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -14,6 +14,8 @@ namespace XmlFormat.MsBuild.Task;
 
 public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
 {
+    public bool UseLocalConfig { get; set; } = false;
+
     public virtual int LineLength { get; set; } = 0;
 
     public virtual string Tabs { get; set; } = string.Empty;

--- a/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
+++ b/XmlFormat.MsBuild.Task/RunXmlFormatFiles.cs
@@ -56,6 +56,13 @@ public class RunXmlFormatFiles : Microsoft.Build.Utilities.Task
         ConfigurationBuilder configBuilder = new();
         configBuilder.AddInMemoryCollection(memoryOptions);
 
+        if (UseLocalConfig)
+        {
+            configBuilder
+                .AddTomlFile(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "xmlformat.toml"), optional: false, reloadOnChange: true)
+                .AddTomlFile(Path.Combine(Environment.CurrentDirectory, ".xmlformat"), optional: true, reloadOnChange: true);
+        }
+
         IConfiguration config = configBuilder.Build();
 
         FormattingOptions formattingOptions = new();

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -86,4 +86,8 @@
     <Content Include="$(MSBuildThisFileDirectory)..\.artifacts\bin\XmlFormat\$(Configuration)\*.dll" PackagePath="lib\netstandard2.0" />
   </ItemGroup>
 
+  <ItemGroup Label="Pack configuration files">
+    <Content Include="$(MSBuildThisFileDirectory)..\XmlFormat.Tool\xmlformat.toml" Link="xmlformat.toml" Pack="true" CopyToOutputDirectory="PreserveNewest" PackagePath="\" />
+  </ItemGroup>
+
 </Project>

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -71,6 +71,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
   </ItemGroup>
 
   <ItemGroup Label="project references">


### PR DESCRIPTION
- **build: add package reference to Alexinea.Extensions.Configuration.Toml**
- **build: bundle `xmlformat.toml` for XmlFormat.Tool with XmlFormat.MSBuild.Task NuGet package**
- **feat: add property UseLocalConfig to RunXmlFormatFiles**
- **feat: load local configuration files if flag set in RunXmlFormatFiles**
