### PR TITLE
build: set CopyLocalLockFileAssemblies flag in XmlFormat.MsBuild.Task project

### DIFF
--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -14,6 +14,7 @@
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <DebugType>embedded</DebugType>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Label="build metadata">


### PR DESCRIPTION
note: this forces all dependency assemblies to be packed in the NuGet package.
caveat: package size increases.
