### PR TITLE
build: remove all conflicting packing instructions from XmlFormat.MSBuild.Task

### DIFF
--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -41,10 +41,6 @@
     <ProjectReference Include="..\XmlFormat\XmlFormat.csproj" />
   </ItemGroup>
 
-  <ItemGroup Label="Pack the tool and related DLLs">
-    <Content Include="$(MSBuildThisFileDirectory)..\.artifacts\bin\XmlFormat\$(Configuration)\*.dll" PackagePath="lib\netstandard2.0" />
-  </ItemGroup>
-
   <ItemGroup Label="Pack configuration files">
     <Content Include="$(MSBuildThisFileDirectory)..\XmlFormat.Tool\xmlformat.toml" Link="xmlformat.toml" Pack="true" CopyToOutputDirectory="PreserveNewest" PackagePath="\" />
   </ItemGroup>


### PR DESCRIPTION
- **build: remove setting property TargetsForTfmSpecificBuildOutput**
- **build: remove setting property CopyLocalLockFileAssemblies**
- **build: remove comment**
- **build: remove target CopyProjectReferencesToPackage**
- **build: remove target AddBuildDependencyFileToBuiltProjectOutputGroupOutput**
- **build: remove target BuildXmlFormat**
- **build: remove packing build artifact assemblies from XmlFormat**
