### PR TITLE
build: use Costura.Fody to merge assemblies for XmlFormat.Tool and XmlFormat.MSBuild.Task

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
 
   <ItemGroup Label="build dependencies">
     <PackageVersion Include="Costura.Fody" Version="6.0.0" />
+    <PackageVersion Include="Fody" Version="6.9.2" />
   </ItemGroup>
 
   <ItemGroup Label="unit test dependencies">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,10 @@
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.14.8" />
   </ItemGroup>
 
+  <ItemGroup Label="build dependencies">
+    <PackageVersion Include="Costura.Fody" Version="6.0.0" />
+  </ItemGroup>
+
   <ItemGroup Label="unit test dependencies">
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <Costura />
+</Weavers>

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
     <PackageReference Include="Costura.Fody" />
+    <PackageReference Include="Fody" />
   </ItemGroup>
 
   <ItemGroup Label="project references">

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -35,6 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
+    <PackageReference Include="Costura.Fody" />
   </ItemGroup>
 
   <ItemGroup Label="project references">

--- a/XmlFormat.Tool/FodyWeavers.xml
+++ b/XmlFormat.Tool/FodyWeavers.xml
@@ -1,0 +1,3 @@
+﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
+  <Costura />
+</Weavers>

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -30,6 +30,7 @@
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="Costura.Fody" />
+    <PackageReference Include="Fody" />
   </ItemGroup>
 
   <ItemGroup Label="project references">

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
     <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="Costura.Fody" />
   </ItemGroup>
 
   <ItemGroup Label="project references">


### PR DESCRIPTION
- **build: add package reference to Costura.Fody v6.0.0**
- **build: add package reference to Fody v6.9.2**
- **feat: add default FodyWeavers.xml to XmlFormat.MsBuild.Task project**
- **feat: add default FodyWeavers.xml to XmlFormat.Tool project**
