### PR TITLE
build: set package and projects references to PrivateAssets in XmlFormat.MSBuild.Task project

### DIFF
--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" PrivateAssets="all" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" PrivateAssets="all" />
-    <PackageReference Include="Superpower" />
+    <PackageReference Include="Superpower" PrivateAssets="all" />
     <PackageReference Include="Costura.Fody" />
     <PackageReference Include="Fody" />
   </ItemGroup>

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -33,7 +33,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" PrivateAssets="all" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
     <PackageReference Include="Superpower" />
     <PackageReference Include="Costura.Fody" />

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" PrivateAssets="all" />
-    <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
+    <PackageReference Include="Alexinea.Extensions.Configuration.Toml" PrivateAssets="all" />
     <PackageReference Include="Superpower" />
     <PackageReference Include="Costura.Fody" />
     <PackageReference Include="Fody" />

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -42,6 +42,7 @@
 
   <ItemGroup Label="project references">
     <ProjectReference Include="..\XmlFormat\XmlFormat.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\XmlFormat\XmlFormat.SAX.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="Pack configuration files">

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -31,10 +31,11 @@
 
   <ItemGroup Label="package references">
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
+    <PackageReference Include="Superpower" />
     <PackageReference Include="Costura.Fody" />
     <PackageReference Include="Fody" />
   </ItemGroup>

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" PrivateAssets="all" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" PrivateAssets="all" />
     <PackageReference Include="Superpower" PrivateAssets="all" />
-    <PackageReference Include="Costura.Fody" />
+    <PackageReference Include="Costura.Fody" PrivateAssets="all" />
     <PackageReference Include="Fody" />
   </ItemGroup>
 

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" PrivateAssets="all" />
     <PackageReference Include="Superpower" PrivateAssets="all" />
     <PackageReference Include="Costura.Fody" PrivateAssets="all" />
-    <PackageReference Include="Fody" />
+    <PackageReference Include="Fody" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="project references">

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -13,6 +13,7 @@
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <DebugType>embedded</DebugType>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Label="build metadata">

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup Label="project references">
-    <ProjectReference Include="..\XmlFormat\XmlFormat.csproj" />
+    <ProjectReference Include="..\XmlFormat\XmlFormat.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="Pack configuration files">

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -32,7 +32,7 @@
   <ItemGroup Label="package references">
     <PackageReference Include="Microsoft.Build.Utilities.Core" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
     <PackageReference Include="Superpower" />


### PR DESCRIPTION
- **build: set package reference Microsoft.Extensions.Configuration to PrivateAssets**
- **build: set package reference Microsoft.Extensions.Configuration.Abstractions to PrivateAssets**
- **build: set package reference Microsoft.Extensions.Configuration.Binder to PrivateAssets**
- **build: set package reference Alexinea.Extensions.Configuration.Toml to PrivateAssets**
- **build: set package reference Superpower to PrivateAssets**
- **build: set package reference Costura.Fody to PrivateAssets**
- **build: set package reference Fody to PrivateAssets**
- **build: set project reference XmlFormat to PrivateAssets**
- **build: add project reference to XmlFormat.SAX with PrivateAssets**
- **build: restore setting property CopyLocalLockFileAssemblies**
