### PR TITLE
fix: add `dummy.log` to allow logfile-less unit tests to pass

### DIFF
--- a/dummy.log
+++ b/dummy.log
@@ -1,0 +1,1 @@
+<dummy.log>


### PR DESCRIPTION
- **feat: add dummy.log**

reason: stupid workaround for failing unit tests when no log file can be found
in which case, at least this one is going to be shown.
