### PR TITLE
build: set package and projects references to PrivateAssets in XmlFormat.Tool project

### DIFF
--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -34,7 +34,7 @@
   </ItemGroup>
 
   <ItemGroup Label="project references">
-    <ProjectReference Include="..\XmlFormat\XmlFormat.csproj" />
+    <ProjectReference Include="..\XmlFormat\XmlFormat.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="configuration files">

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="package references">
-    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup Label="project references">
     <ProjectReference Include="..\XmlFormat\XmlFormat.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\XmlFormat.SAX\XmlFormat.SAX.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="configuration files">

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" PrivateAssets="all" />
     <PackageReference Include="CommandLineParser" PrivateAssets="all" />
     <PackageReference Include="Costura.Fody" PrivateAssets="all" />
-    <PackageReference Include="Fody" />
+    <PackageReference Include="Fody" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="project references">

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" PrivateAssets="all" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" PrivateAssets="all" />
-    <PackageReference Include="CommandLineParser" />
+    <PackageReference Include="CommandLineParser" PrivateAssets="all" />
     <PackageReference Include="Costura.Fody" />
     <PackageReference Include="Fody" />
   </ItemGroup>

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -25,7 +25,7 @@
   <ItemGroup Label="package references">
     <PackageReference Include="Microsoft.Extensions.Configuration" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
     <PackageReference Include="CommandLineParser" />

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" PrivateAssets="all" />
-    <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
+    <PackageReference Include="Alexinea.Extensions.Configuration.Toml" PrivateAssets="all" />
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="Costura.Fody" />
     <PackageReference Include="Fody" />

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" PrivateAssets="all" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" PrivateAssets="all" />
     <PackageReference Include="CommandLineParser" PrivateAssets="all" />
-    <PackageReference Include="Costura.Fody" />
+    <PackageReference Include="Costura.Fody" PrivateAssets="all" />
     <PackageReference Include="Fody" />
   </ItemGroup>
 

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup Label="package references">
     <PackageReference Include="Microsoft.Extensions.Configuration" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" PrivateAssets="all" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" />
     <PackageReference Include="CommandLineParser" />
     <PackageReference Include="Costura.Fody" />


### PR DESCRIPTION
- **build: set package reference Microsoft.Extensions.Configuration to PrivateAssets**
- **build: set package reference Microsoft.Extensions.Configuration.Abstractions to PrivateAssets**
- **build: set package reference Microsoft.Extensions.Configuration.Binder to PrivateAssets**
- **build: set package reference Microsoft.Extensions.Configuration.CommandLine to PrivateAssets**
- **build: set package reference Alexinea.Extensions.Configuration.Toml to PrivateAssets**
- **build: set package reference CommandLineParser to PrivateAssets**
- **build: set package reference Costura.Fody to PrivateAssets**
- **build: set package reference Fody to PrivateAssets**
- **build: set project reference XmlFormat to PrivateAssets**
- **build: add project reference to XmlFormat.SAX with PrivateAssets**
