### PR TITLE
build: set up FodyWeavers configuration for minimal viable XmlFormat.MSBuild.Task assembly size

### DIFF
--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -10,6 +10,7 @@
       Microsoft.Extensions.FileProviders.Abstractions
       Microsoft.Extensions.FileProviders.Physical
       Microsoft.Extensions.FileSystemGlobbing
+      Microsoft.Extensions.Primitives
     </IncludeAssemblies>
 
   </Costura>

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -7,6 +7,7 @@
       Microsoft.Extensions.Configuration.Binder
       Alexinea.Extensions.Configuration.Toml
       Microsoft.Extensions.FileProviders.Abstractions
+      Microsoft.Extensions.FileProviders.Physical
     </IncludeAssemblies>
 
   </Costura>

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -6,6 +6,7 @@
       Microsoft.Extensions.Configuration.Abstractions
       Microsoft.Extensions.Configuration.Binder
       Alexinea.Extensions.Configuration.Toml
+      Microsoft.Extensions.FileProviders.Abstractions
     </IncludeAssemblies>
 
   </Costura>

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -11,6 +11,7 @@
       Microsoft.Extensions.FileProviders.Physical
       Microsoft.Extensions.FileSystemGlobbing
       Microsoft.Extensions.Primitives
+      Nett
     </IncludeAssemblies>
 
   </Costura>

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -12,6 +12,7 @@
       Microsoft.Extensions.FileSystemGlobbing
       Microsoft.Extensions.Primitives
       Nett
+      Superpower
     </IncludeAssemblies>
 
   </Costura>

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -5,6 +5,7 @@
       Microsoft.Extensions.Configuration
       Microsoft.Extensions.Configuration.Abstractions
       Microsoft.Extensions.Configuration.Binder
+      Alexinea.Extensions.Configuration.Toml
     </IncludeAssemblies>
 
   </Costura>

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -14,6 +14,7 @@
       Nett
       Superpower
       XmlFormat
+      XmlFormat.SAX
     </IncludeAssemblies>
 
   </Costura>

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -9,6 +9,7 @@
       Alexinea.Extensions.Configuration.Toml
       Microsoft.Extensions.FileProviders.Abstractions
       Microsoft.Extensions.FileProviders.Physical
+      Microsoft.Extensions.FileSystemGlobbing
     </IncludeAssemblies>
 
   </Costura>

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -5,6 +5,7 @@
       Microsoft.Extensions.Configuration
       Microsoft.Extensions.Configuration.Abstractions
       Microsoft.Extensions.Configuration.Binder
+      Microsoft.Extensions.Configuration.FileExtensions
       Alexinea.Extensions.Configuration.Toml
       Microsoft.Extensions.FileProviders.Abstractions
       Microsoft.Extensions.FileProviders.Physical

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -1,3 +1,9 @@
 ﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura />
+  <Costura>
+
+    <IncludeAssemblies>
+      Microsoft.Extensions.Configuration
+    </IncludeAssemblies>
+
+  </Costura>
 </Weavers>

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -3,6 +3,7 @@
 
     <IncludeAssemblies>
       Microsoft.Extensions.Configuration
+      Microsoft.Extensions.Configuration.Abstractions
     </IncludeAssemblies>
 
   </Costura>

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -13,6 +13,7 @@
       Microsoft.Extensions.Primitives
       Nett
       Superpower
+      XmlFormat
     </IncludeAssemblies>
 
   </Costura>

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -4,6 +4,7 @@
     <IncludeAssemblies>
       Microsoft.Extensions.Configuration
       Microsoft.Extensions.Configuration.Abstractions
+      Microsoft.Extensions.Configuration.Binder
     </IncludeAssemblies>
 
   </Costura>

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -13,7 +13,6 @@
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
     <DebugType>embedded</DebugType>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Label="build metadata">


### PR DESCRIPTION
- **build: add Microsoft.Extensions.Configuration to IncludeAssemblies section in FodyWeavers configuration**
- **build: add Microsoft.Extensions.Configuration.Abstractions to IncludeAssemblies section in FodyWeavers configuration**
- **build: add Microsoft.Extensions.Configuration.Binder to IncludeAssemblies section in FodyWeavers configuration**
- **build: add Alexinea.Extensions.Configuration.Toml to IncludeAssemblies section in FodyWeavers configuration**
- **build: add Microsoft.Extensions.FileProviders.Abstractions to IncludeAssemblies section in FodyWeavers configuration**
- **build: add Microsoft.Extensions.FileProviders.Physical to IncludeAssemblies section in FodyWeavers configuration**
- **build: add Microsoft.Extensions.Configuration.FileExtensions to IncludeAssemblies section in FodyWeavers configuration**
- **build: add Microsoft.Extensions.FileSystemGlobbing to IncludeAssemblies section in FodyWeavers configuration**
- **build: add Microsoft.Extensions.Primitives to IncludeAssemblies section in FodyWeavers configuration**
- **build: add Nett to IncludeAssemblies section in FodyWeavers configuration**
- **build: add Superpower to IncludeAssemblies section in FodyWeavers configuration**
- **build: add XmlFormat to IncludeAssemblies section in FodyWeavers configuration**
- **build: add XmlFormat.SAX to IncludeAssemblies section in FodyWeavers configuration**
- **build: remove setting property CopyLocalLockFileAssemblies (again)**
