### PR TITLE
build: replace Costura.Fody -> ILMerge.Fody for IL merging instead of assembly embedding

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
   </ItemGroup>
 
   <ItemGroup Label="build dependencies">
+    <PackageVersion Include="ILMerge.Fody" Version="1.24.0" />
     <PackageVersion Include="Costura.Fody" Version="6.0.0" />
     <PackageVersion Include="Fody" Version="6.9.2" />
   </ItemGroup>

--- a/XmlFormat.MsBuild.Task/FodyWeavers.xml
+++ b/XmlFormat.MsBuild.Task/FodyWeavers.xml
@@ -1,7 +1,6 @@
 ﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura>
-
-    <IncludeAssemblies>
+  <ILMerge>
+    <IncludeAssemblies CompactMode='true'>
       Microsoft.Extensions.Configuration
       Microsoft.Extensions.Configuration.Abstractions
       Microsoft.Extensions.Configuration.Binder
@@ -16,6 +15,5 @@
       XmlFormat
       XmlFormat.SAX
     </IncludeAssemblies>
-
-  </Costura>
+  </ILMerge>
 </Weavers>

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" PrivateAssets="all" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" PrivateAssets="all" />
     <PackageReference Include="Superpower" PrivateAssets="all" />
-    <PackageReference Include="Costura.Fody" PrivateAssets="all" />
+    <PackageReference Include="ILMerge.Fody" PrivateAssets="all" />
     <PackageReference Include="Fody" PrivateAssets="all" />
   </ItemGroup>
 

--- a/XmlFormat.Tool/FodyWeavers.xml
+++ b/XmlFormat.Tool/FodyWeavers.xml
@@ -1,5 +1,5 @@
 ﻿<Weavers xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="FodyWeavers.xsd">
-  <Costura>
+  <ILMerge>
     <IncludeAssemblies>
       Microsoft.Extensions.Configuration
       Microsoft.Extensions.Configuration.Abstractions
@@ -15,5 +15,5 @@
       XmlFormat
       XmlFormat.SAX
     </IncludeAssemblies>
-  </Costura>
+  </ILMerge>
 </Weavers>

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" PrivateAssets="all" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" PrivateAssets="all" />
     <PackageReference Include="CommandLineParser" PrivateAssets="all" />
-    <PackageReference Include="Costura.Fody" PrivateAssets="all" />
+    <PackageReference Include="ILMerge.Fody" PrivateAssets="all" />
     <PackageReference Include="Fody" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
- **build: add package reference to ILMerge.Fody v1.24.0**
- **build: replace package reference to Costura.Fody -> ILMerge.Fody in XmlFormat.MsBuild.Task project**
- **build: replace package reference to Costura.Fody -> ILMerge.Fody in XmlFormat.Tool project**
