### PR TITLE
build: use ILRepack to internalize reference assemblies with XmlFormat.MSBuild.Task

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,6 +18,7 @@
   <ItemGroup Label="build dependencies">
     <PackageVersion Include="Costura.Fody" Version="6.0.0" />
     <PackageVersion Include="Fody" Version="6.9.2" />
+    <PackageVersion Include="ILRepack.Lib.MSBuild.Task" Version="2.0.43" />
   </ItemGroup>
 
   <ItemGroup Label="unit test dependencies">

--- a/XmlFormat.MsBuild.Task/ILRepack.Config.props
+++ b/XmlFormat.MsBuild.Task/ILRepack.Config.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/XmlFormat.MsBuild.Task/ILRepack.targets
+++ b/XmlFormat.MsBuild.Task/ILRepack.targets
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="ILRepacker" AfterTargets="Build">
+    <ItemGroup>
+      <InputAssemblies Include="$(TargetPath)" />
+
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'XmlFormat'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'XmlFormat.SAX'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Nett'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Superpower'" />
+
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Alexinea.Extensions.Configuration.Toml'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.Configuration.Abstractions'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.Configuration.Binder'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.Configuration'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.Configuration.FileExtensions'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.FileProviders.Abstractions'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.FileProviders.Physical'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.FileSystemGlobbing'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.Primitives'" />
+
+      <LibraryPath Include="%(ReferencePathWithRefAssemblies.RelativeDir)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <DoNotInternalizeAssemblies Include="$(AssemblyName)" />
+      <DoNotInternalizeAssemblies Include="XmlFormat" />
+      <DoNotInternalizeAssemblies Include="XmlFormat.SAX" />
+
+      <!-- not internalized b/c of runtime-mapped functions not matching otherwise -->
+      <DoNotInternalizeAssemblies Include="Alexinea.Extensions.Configuration.Toml" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.Configuration.Abstractions" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.Configuration.Binder" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.Configuration" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.Configuration.FileExtensions" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.FileProviders.Abstractions" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.FileProviders.Physical" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.FileSystemGlobbing" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.Primitives" />
+    </ItemGroup>
+
+    <ILRepack
+      Parallel="true"
+      DebugInfo="true"
+      Internalize="true"
+      InputAssemblies="@(InputAssemblies)"
+      InternalizeExclude="@(DoNotInternalizeAssemblies)"
+      LibraryPath="@(LibraryPath)"
+      TargetKind="SameAsPrimaryAssembly"
+      OutputFile="$(TargetPath)"
+      RenameInternalized="true"
+    />
+  </Target>
+
+</Project>

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -36,8 +36,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" PrivateAssets="all" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" PrivateAssets="all" />
     <PackageReference Include="Superpower" PrivateAssets="all" />
-    <PackageReference Include="Costura.Fody" PrivateAssets="all" />
-    <PackageReference Include="Fody" PrivateAssets="all" />
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" PrivateAssets="all" />
   </ItemGroup>
 

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Superpower" PrivateAssets="all" />
     <PackageReference Include="Costura.Fody" PrivateAssets="all" />
     <PackageReference Include="Fody" PrivateAssets="all" />
+    <PackageReference Include="ILRepack.Lib.MSBuild.Task" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="project references">


### PR DESCRIPTION
- **build: add package reference to ILRepack.Lib.MSBuild.Task v2.0.43**
- **build: remove package references to Costura.Fody and Fody**
- **build: add ILRepack post-build target to project configuration**
