### PR TITLE
build: use ILRepack to internalize reference assemblies with XmlFormat.Tool

### DIFF
--- a/XmlFormat.Tool/ILRepack.Config.props
+++ b/XmlFormat.Tool/ILRepack.Config.props
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="ILRepacker" AfterTargets="Build">
+    <ItemGroup>
+      <InputAssemblies Include="$(TargetPath)" />
+
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'XmlFormat'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'XmlFormat.SAX'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Nett'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Superpower'" />
+
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Alexinea.Extensions.Configuration.Toml'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.Configuration'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.Configuration.Abstractions'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.Configuration.Binder'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.Configuration.CommandLine'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.Configuration.FileExtensions'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.FileProviders.Abstractions'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.FileProviders.Physical'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.FileSystemGlobbing'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'Microsoft.Extensions.Primitives'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'CommandLineParser'" />
+      <InputAssemblies Include="@(ReferencePath)" Condition="'%(FileName)' == 'CommandLine'" />
+
+      <LibraryPath Include="%(ReferencePathWithRefAssemblies.RelativeDir)" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <DoNotInternalizeAssemblies Include="$(AssemblyName)" />
+
+      <!-- not internalized b/c of runtime-mapped functions not matching otherwise -->
+      <DoNotInternalizeAssemblies Include="Alexinea.Extensions.Configuration.Toml" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.Configuration.Abstractions" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.Configuration.Binder" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.Configuration" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.Configuration.FileExtensions" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.FileProviders.Abstractions" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.FileProviders.Physical" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.FileSystemGlobbing" />
+      <DoNotInternalizeAssemblies Include="Microsoft.Extensions.Primitives" />
+    </ItemGroup>
+
+    <ILRepack
+      Parallel="true"
+      DebugInfo="true"
+      Internalize="true"
+      InputAssemblies="@(InputAssemblies)"
+      InternalizeExclude="@(DoNotInternalizeAssemblies)"
+      LibraryPath="@(LibraryPath)"
+      TargetKind="SameAsPrimaryAssembly"
+      OutputFile="$(TargetPath)"
+      RenameInternalized="true"
+    />
+  </Target>
+
+</Project>

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -29,8 +29,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" PrivateAssets="all" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" PrivateAssets="all" />
     <PackageReference Include="CommandLineParser" PrivateAssets="all" />
-    <PackageReference Include="Costura.Fody" PrivateAssets="all" />
-    <PackageReference Include="Fody" PrivateAssets="all" />
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" PrivateAssets="all" />
   </ItemGroup>
 

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -31,6 +31,7 @@
     <PackageReference Include="CommandLineParser" PrivateAssets="all" />
     <PackageReference Include="Costura.Fody" PrivateAssets="all" />
     <PackageReference Include="Fody" PrivateAssets="all" />
+    <PackageReference Include="ILRepack.Lib.MSBuild.Task" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="project references">


### PR DESCRIPTION
- **build: add package reference to ILRepack.Lib.MSBuild.Task**
- **build: remove package references to Costura.Fody and Fody**
- **build: add ILRepack post-build target to project configuration**
