### PR TITLE
build: run ILRepacker as post-publishing task for XmlFormat.Tool

### DIFF
--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -3,6 +3,8 @@
 
   <Target Name="ILRepacker" AfterTargets="Publish">
 
+    <Message Text="Repacking $(PublishDir)" Importance="high" />
+
     <PropertyGroup>
       <PublishedMainAssembly>$(PublishDir)$(AssemblyName).dll</PublishedMainAssembly>
     </PropertyGroup>
@@ -18,6 +20,7 @@
       <DoNotInternalizeAssemblies Include="$(PublishedMainAssembly)" />
     </ItemGroup>
 
+    <Message Text="Repacking assemblies in $(PublishDir): @(InputAssemblies) ..." Importance="high" />
     <ILRepack
       Parallel="true"
       DebugInfo="true"

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -2,6 +2,11 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <Target Name="ILRepacker" AfterTargets="Publish">
+
+    <PropertyGroup>
+      <PublishedMainAssembly>$(PublishDir)$(AssemblyName).dll</PublishedMainAssembly>
+    </PropertyGroup>
+
     <ItemGroup>
       <InputAssemblies Include="$(TargetPath)" />
       <InputAssemblies Include="@(ReferenceCopyLocalPaths)" />

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -34,6 +34,17 @@
       OutputFile="$(PublishedMainAssembly)"
       LogFile="$(PublishDir)$(AssemblyName).ilrepack.log"
     />
+
+    <ItemGroup>
+      <FilesToDelete Include="$(PublishDir)*.dll" Exclude="$(PublishedMainAssembly)" />
+      <FilesToDelete Include="$(PublishDir)*.pdb" Exclude="$(PublishDir)$(TargetName).pdb" />
+      <FilesToDelete Include="$(PublishDir)*.deps.json" />
+    </ItemGroup>
+
+    <Message Text="Cleaning up merged files: @(FilesToDelete)" Importance="normal" />
+    <Delete Files="@(FilesToDelete)" />
+
   </Target>
+
 
 </Project>

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -8,14 +8,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <InputAssemblies Include="$(TargetPath)" />
-      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" />
+      <InputAssemblies Include="$(PublishedMainAssembly)" />
+      <InputAssemblies Include="$(PublishDir)*.dll" Exclude="$(PublishedMainAssembly)" />
 
-      <LibraryPath Include="%(ReferencePathWithRefAssemblies.RelativeDir)" />
+      <LibraryPath Include="$(PublishDir)" />
     </ItemGroup>
 
     <ItemGroup>
-      <DoNotInternalizeAssemblies Include="$(AssemblyName)" />
+      <DoNotInternalizeAssemblies Include="$(PublishedMainAssembly)" />
     </ItemGroup>
 
     <ILRepack
@@ -28,8 +28,8 @@
       LibraryPath="@(LibraryPath)"
       TargetKind="SameAsPrimaryAssembly"
 
-      OutputFile="$(TargetPath)"
-      LogFile="$(TargetPath).ilrepack.log"
+      OutputFile="$(PublishedMainAssembly)"
+      LogFile="$(PublishDir)$(AssemblyName).ilrepack.log"
     />
   </Target>
 

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="ILRepacker" AfterTargets="Build">
+  <Target Name="ILRepacker" AfterTargets="Publish">
     <ItemGroup>
       <InputAssemblies Include="$(TargetPath)" />
       <InputAssemblies Include="@(ReferenceCopyLocalPaths)" />


### PR DESCRIPTION
- **build: run ILRepacker task after target Publish**
- **build: add property `PublishedMainAssembly` to ILRepacker task**
- **build: replace reference assembly paths with published assembly paths**
- **build: print debug messages**
- **build: delete merged assemblies from output directory after merging**
