### PR TITLE
build: run ILRepacker step after Build for XmlFormat.Tool project

### DIFF
--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -3,24 +3,24 @@
 
   <Target Name="ILRepacker" AfterTargets="Build">
 
-    <Message Text="Repacking $(PublishDir)" Importance="high" />
+    <Message Text="Repacking $(OutputPath)" Importance="high" />
 
     <PropertyGroup>
-      <PublishedMainAssembly>$(PublishDir)$(AssemblyName).dll</PublishedMainAssembly>
+      <PublishedMainAssembly>$(OutputPath)$(AssemblyName).dll</PublishedMainAssembly>
     </PropertyGroup>
 
     <ItemGroup>
       <InputAssemblies Include="$(PublishedMainAssembly)" />
-      <InputAssemblies Include="$(PublishDir)*.dll" Exclude="$(PublishedMainAssembly)" />
+      <InputAssemblies Include="$(OutputPath)*.dll" Exclude="$(PublishedMainAssembly)" />
 
-      <LibraryPath Include="$(PublishDir)" />
+      <LibraryPath Include="$(OutputPath)" />
     </ItemGroup>
 
     <ItemGroup>
       <DoNotInternalizeAssemblies Include="$(PublishedMainAssembly)" />
     </ItemGroup>
 
-    <Message Text="Repacking assemblies in $(PublishDir): @(InputAssemblies) ..." Importance="high" />
+    <Message Text="Repacking assemblies in $(OutputPath): @(InputAssemblies) ..." Importance="high" />
     <ILRepack
       Parallel="true"
       DebugInfo="true"
@@ -32,13 +32,13 @@
       TargetKind="SameAsPrimaryAssembly"
 
       OutputFile="$(PublishedMainAssembly)"
-      LogFile="$(PublishDir)$(AssemblyName).ilrepack.log"
+      LogFile="$(OutputPath)$(AssemblyName).ilrepack.log"
     />
 
     <ItemGroup>
-      <FilesToDelete Include="$(PublishDir)*.dll" Exclude="$(PublishedMainAssembly)" />
-      <FilesToDelete Include="$(PublishDir)*.pdb" Exclude="$(PublishDir)$(TargetName).pdb" />
-      <FilesToDelete Include="$(PublishDir)*.deps.json" />
+      <FilesToDelete Include="$(OutputPath)*.dll" Exclude="$(PublishedMainAssembly)" />
+      <FilesToDelete Include="$(OutputPath)*.pdb" Exclude="$(OutputPath)$(TargetName).pdb" />
+      <FilesToDelete Include="$(OutputPath)*.deps.json" />
     </ItemGroup>
 
     <Message Text="Cleaning up merged files: @(FilesToDelete)" Importance="normal" />

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="ILRepacker" AfterTargets="Publish">
+  <Target Name="ILRepacker" AfterTargets="Build">
 
     <Message Text="Repacking $(PublishDir)" Importance="high" />
 

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -8,9 +8,10 @@
     <IsPackable>true</IsPackable>
     <IsPublishable>true</IsPublishable>
     <PackRelease>true</PackRelease>
-    <PublishRelease>true</PublishRelease>
     <PackAsTool>true</PackAsTool>
+    <PublishRelease>true</PublishRelease>
     <ToolCommandName>xf</ToolCommandName>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Label="build metadata">


### PR DESCRIPTION
- **build: run ILRepacker task after target Build**
- **build: use `$(OutputPath)` instead of `$(PublishDir)`**
- **build: set CopyLocalLockFileAssemblies flag in XmlFormat.Tool project**
