### PR TITLE
build: pass verbosity option to `dotnet` commands in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -9,7 +9,7 @@ r restore:
 	dotnet restore -bl -v d
 
 c clean:
-	dotnet clean
+	dotnet clean -bl -v d
 	rm -rf .artifacts
 
 b build:

--- a/makefile
+++ b/makefile
@@ -16,7 +16,7 @@ b build:
 	dotnet build -bl -v d
 
 p pack:
-	dotnet pack
+	dotnet pack -bl -v d
 
 t test:
 	dotnet test

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ f format:
 	@fd csproj$$ -X dos2unix -q -r {}
 
 r restore:
-	dotnet restore
+	dotnet restore -bl -v d
 
 c clean:
 	dotnet clean

--- a/makefile
+++ b/makefile
@@ -13,7 +13,7 @@ c clean:
 	rm -rf .artifacts
 
 b build:
-	dotnet build
+	dotnet build -bl -v d
 
 p pack:
 	dotnet pack

--- a/makefile
+++ b/makefile
@@ -19,7 +19,7 @@ p pack:
 	dotnet pack -bl -v d
 
 t test:
-	dotnet test
+	dotnet test -bl -v d
 	dotnet run --project XmlFormat.Tool -- --help
 	dotnet run --project XmlFormat.Tool -- --version
 	dotnet run --project XmlFormat.Tool -- --inline test.xml


### PR DESCRIPTION
- **build: pass verbosity option to `dotnet restore` in restore makerule**
- **build: pass verbosity option to `dotnet clean` in clean makerule**
- **build: pass verbosity option to `dotnet build` in build makerule**
- **build: pass verbosity option to `dotnet pack` in pack makerule**
- **build: pass verbosity option to `dotnet test` in test makerule**
