### PR TITLE
build: streamline XmlFormat properties in Standalone tests

### DIFF
--- a/Tests/MsBuild.Task.Standalone.Test/Directory.Build.props
+++ b/Tests/MsBuild.Task.Standalone.Test/Directory.Build.props
@@ -60,6 +60,14 @@
     <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
 
+  <PropertyGroup Label="XmlFormat configuration">
+    <XmlFormat>enable</XmlFormat>
+    <XmlFormatLineLength>142</XmlFormatLineLength>
+    <XmlFormatTabs> </XmlFormatTabs>
+    <XmlFormatTabsRepeat>3</XmlFormatTabsRepeat>
+    <XmlFormatMaxEmptyLines>5</XmlFormatMaxEmptyLines>
+  </PropertyGroup>
+
   <ItemGroup Label="source link settings">
     <SourceLinkGitHubHost Include="github.com" ContentUrl="https://raw.github.com"/>
   </ItemGroup>

--- a/Tests/MsBuild.Task.Standalone.Test/Directory.Build.targets
+++ b/Tests/MsBuild.Task.Standalone.Test/Directory.Build.targets
@@ -1,8 +1,10 @@
 <Project>
+
+  <!--
   <Target Name="CreatePackage" BeforeTargets="Build">
     <Message Importance="high" Text="Creating package" />
     <Exec Command="cd $(MSBuildThisFileDirectory)..\..; dotnet pack -o $(MSBuildThisFileDirectory)\packages"/>
   </Target>
-
+  -->
 
 </Project>

--- a/Tests/MsBuild.Task.Standalone.Test/Directory.Build.targets
+++ b/Tests/MsBuild.Task.Standalone.Test/Directory.Build.targets
@@ -3,9 +3,6 @@
     <Message Importance="high" Text="Creating package" />
     <Exec Command="cd $(MSBuildThisFileDirectory)..\..; dotnet pack -o $(MSBuildThisFileDirectory)\packages"/>
   </Target>
-  <Target Name="GenerateChangelog" BeforeTargets="Pack">
-    <Message Importance="high" Text="Generating CHANGELOG.md" />
-    <Exec Command="git log --reverse --pretty='* %s' > $(MSBuildThisFileDirectory)CHANGELOG.md"/>
-    <Exec Command="cat $(MSBuildThisFileDirectory)CHANGELOG.md"/>
-  </Target>
+
+
 </Project>

--- a/Tests/MsBuild.Task.Standalone.Test/Directory.Packages.props
+++ b/Tests/MsBuild.Task.Standalone.Test/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup Label="local package">
-    <PackageVersion Include="KageKirin.XmlFormat.MSBuild.Task" Version="0.4.10" />
+    <PackageVersion Include="KageKirin.XmlFormat.MSBuild.Task" Version="0.5.10" />
   </ItemGroup>
 
   <ItemGroup Label="global package references">

--- a/Tests/MsBuild.Task.Standalone.Test/MsBuild.Task.Standalone.Test.Lib/MsBuild.Task.Standalone.Test.Lib.csproj
+++ b/Tests/MsBuild.Task.Standalone.Test/MsBuild.Task.Standalone.Test.Lib/MsBuild.Task.Standalone.Test.Lib.csproj
@@ -10,8 +10,11 @@
     <PackageReference Include="KageKirin.XmlFormat.MSBuild.Task" />
   </ItemGroup>
 
-  <PropertyGroup Label="enable XmlFormat">
-    <XmlFormat>enable</XmlFormat>
+  <PropertyGroup Label="XmlFormat configuration">
+    <XmlFormatLineLength>163</XmlFormatLineLength>
+    <XmlFormatTabs>   </XmlFormatTabs>
+    <XmlFormatTabsRepeat>2</XmlFormatTabsRepeat>
+    <XmlFormatMaxEmptyLines>3</XmlFormatMaxEmptyLines>
   </PropertyGroup>
 
   <ItemGroup Label="xml format these files">

--- a/Tests/MsBuild.Task.Standalone.Test/MsBuild.Task.Standalone.Test.Lib/MsBuild.Task.Standalone.Test.Lib.csproj
+++ b/Tests/MsBuild.Task.Standalone.Test/MsBuild.Task.Standalone.Test.Lib/MsBuild.Task.Standalone.Test.Lib.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup Label="xml format these files">
     <XmlFormatFile Include="foobar.xml" />
-    <XmlFormatFile Include="**/*.xml" />
+    <XmlFormatFile Include="**\*.xml" />
   </ItemGroup>
 
 </Project>

--- a/Tests/MsBuild.Task.Standalone.Test/MsBuild.Task.Standalone.Test/MsBuild.Task.Standalone.Test.csproj
+++ b/Tests/MsBuild.Task.Standalone.Test/MsBuild.Task.Standalone.Test/MsBuild.Task.Standalone.Test.csproj
@@ -11,8 +11,8 @@
     <PackageReference Include="KageKirin.XmlFormat.MSBuild.Task" />
   </ItemGroup>
 
-  <PropertyGroup Label="enable XmlFormat">
-    <XmlFormat>enable</XmlFormat>
+  <PropertyGroup Label="XmlFormat Settings">
+    <XmlFormatLineLength>142</XmlFormatLineLength>
   </PropertyGroup>
 
   <ItemGroup Label="xml format these files">

--- a/Tests/MsBuild.Task.Standalone.Test/MsBuild.Task.Standalone.Test/MsBuild.Task.Standalone.Test.csproj
+++ b/Tests/MsBuild.Task.Standalone.Test/MsBuild.Task.Standalone.Test/MsBuild.Task.Standalone.Test.csproj
@@ -15,9 +15,8 @@
     <XmlFormatLineLength>142</XmlFormatLineLength>
   </PropertyGroup>
 
-  <ItemGroup Label="xml format these files">
-    <XmlFormatFile Include="foobar.xml" />
-    <XmlFormatFile Include="**/*.xml" />
+  <ItemGroup>
+    <XmlFormatFile Include="**\*.xml" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- **build: remove duplicate GenerateChangelog target in Standalone tests**
- **build: disable CreatePackage target in Standalone tests**
- **build: add common properties for XmlFormat in Standalone tests**
- **build: override common properties for XmlFormat in Standalone.Lib test**
- **build: override common properties for XmlFormat in Standalone test**
- **build: improve wildcard pattern for XmlFormatFile in Standalone tests**
- **build: bump PackageVersion for KageKirin.XmlFormat.MSBuild.Task to v0.5.10 in Standalone tests**
