### PR TITLE
build: run ILRepack on the intermediate assembly for XmlFormat.Tool

### DIFF
--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -6,14 +6,14 @@
     <Message Text="ILRepacker: Merging dependencies into intermediate assembly..." Importance="high" />
 
     <ItemGroup>
-      <InputAssemblies Include="$(TargetPath)" />
-      <InputAssemblies Include="$(OutputPath)*.dll" Exclude="$(TargetPath)" />
+      <InputAssemblies Include="$(IntermediateOutputPath)$(TargetFileName)" />
+      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" />
 
-      <LibraryPath Include="$(OutputPath)" />
+      <LibraryPath Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)')" />
     </ItemGroup>
 
     <ItemGroup>
-      <DoNotInternalizeAssemblies Include="$(TargetPath)" />
+      <DoNotInternalizeAssemblies Include="$(IntermediateOutputPath)$(TargetFileName)" />
     </ItemGroup>
 
     <Message Text="Repacking referenced assembly %(InputAssemblies.Identity) into $(IntermediateOutputPath)$(TargetFileName) ..." Importance="high" />

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -7,7 +7,10 @@
 
     <ItemGroup>
       <InputAssemblies Include="$(IntermediateOutputPath)$(TargetFileName)" />
-      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" />
+
+      <_SystemDependencies Include="@(ReferenceCopyLocalPaths)"
+                           Condition="$([System.String]::new('%(Filename)').StartsWith('System.')) or '%(Filename)' == 'System'" />
+      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" Exclude="@(_SystemDependencies)" />
 
       <LibraryPath Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)')" />
     </ItemGroup>

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -19,7 +19,7 @@
       <DoNotInternalizeAssemblies Include="$(IntermediateOutputPath)$(TargetFileName)" />
     </ItemGroup>
 
-    <Message Text="Repacking referenced assembly %(InputAssemblies.Identity) into $(IntermediateOutputPath)$(TargetFileName) ..." Importance="high" />
+    <Message Text="Repacking referenced assemblies:%0A    📦 @(InputAssemblies, '%0A    📦 ')%0A into $(IntermediateOutputPath)$(TargetFileName) ..." Importance="high" />
     <ILRepack
       Parallel="true"
       DebugInfo="true"

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -26,9 +26,8 @@
       InternalizeExclude="@(DoNotInternalizeAssemblies)"
       LibraryPath="@(LibraryPath)"
       TargetKind="SameAsPrimaryAssembly"
-
-      OutputFile="$(TargetPath)"
-      LogFile="$(OutputPath)$(AssemblyName).ilrepack.log"
+      OutputFile="$(IntermediateOutputPath)$(TargetFileName)"
+      LogFile="$(IntermediateOutputPath)$(AssemblyName).ilrepack.log"
     />
 
     <ItemGroup>

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -15,10 +15,6 @@
       <LibraryPath Include="@(ReferenceCopyLocalPaths->'%(RootDir)%(Directory)')" />
     </ItemGroup>
 
-    <ItemGroup>
-      <DoNotInternalizeAssemblies Include="$(IntermediateOutputPath)$(TargetFileName)" />
-    </ItemGroup>
-
     <Message Text="Repacking referenced assemblies:%0A    📦 @(InputAssemblies, '%0A    📦 ')%0A into $(IntermediateOutputPath)$(TargetFileName) ..." Importance="high" />
     <ILRepack
       Parallel="true"
@@ -26,7 +22,6 @@
       Internalize="true"
       RenameInternalized="false"
       InputAssemblies="@(InputAssemblies)"
-      InternalizeExclude="@(DoNotInternalizeAssemblies)"
       LibraryPath="@(LibraryPath)"
       TargetKind="SameAsPrimaryAssembly"
       OutputFile="$(IntermediateOutputPath)$(TargetFileName)"

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -3,7 +3,7 @@
 
   <Target Name="ILRepacker" AfterTargets="Compile" DependsOnTargets="ResolveAssemblyReferences">
 
-    <Message Text="Repacking $(OutputPath)" Importance="high" />
+    <Message Text="ILRepacker: Merging dependencies into intermediate assembly..." Importance="high" />
 
     <ItemGroup>
       <InputAssemblies Include="$(TargetPath)" />
@@ -16,7 +16,7 @@
       <DoNotInternalizeAssemblies Include="$(TargetPath)" />
     </ItemGroup>
 
-    <Message Text="Repacking assemblies in $(OutputPath): @(InputAssemblies) ..." Importance="high" />
+    <Message Text="Repacking referenced assembly %(InputAssemblies.Identity) into $(IntermediateOutputPath)$(TargetFileName) ..." Importance="high" />
     <ILRepack
       Parallel="true"
       DebugInfo="true"

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="ILRepacker" AfterTargets="Build">
+  <Target Name="ILRepacker" AfterTargets="Compile" DependsOnTargets="ResolveAssemblyReferences">
 
     <Message Text="Repacking $(OutputPath)" Importance="high" />
 

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -30,15 +30,6 @@
       LogFile="$(IntermediateOutputPath)$(AssemblyName).ilrepack.log"
     />
 
-    <ItemGroup>
-      <FilesToDelete Include="$(OutputPath)*.dll" Exclude="$(TargetPath)" />
-      <FilesToDelete Include="$(OutputPath)*.pdb" Exclude="$(OutputPath)$(TargetName).pdb" />
-      <FilesToDelete Include="$(OutputPath)*.deps.json" />
-    </ItemGroup>
-
-    <Message Text="Cleaning up merged files: @(FilesToDelete)" Importance="normal" />
-    <Delete Files="@(FilesToDelete)" />
-
   </Target>
 
 

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -11,7 +11,6 @@
     <PackAsTool>true</PackAsTool>
     <PublishRelease>true</PublishRelease>
     <ToolCommandName>xf</ToolCommandName>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Label="build metadata">


### PR DESCRIPTION
- **build: remove setting property CopyLocalLockFileAssemblies**
- **build: run ILRepacker task after target `Compile`**
- **build: change messages to fit inputs**
- **build: change ILRepack inputs to intermediate assemblies**
- **build: change ILRepack outputs to intermediate assemblies**
- **build: remove deleting of merged assemblies**
- **build: exclude system assemblies from ILRepack inputs**
- **build: improve debug message for input assemblies**
- **build: remove passing DoNotInternalizeAssemblies items to InternalizeExclude argument**
