### PR TITLE
build: split off `@(MainAssembly)` from `@(InputAssemblies)` for XmlFormat.Tool

### DIFF
--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -7,13 +7,13 @@
 
     <ItemGroup>
       <MainAssembly Include="$(TargetPath)" />
-      <InputAssemblies Include="$(OutputPath)*.dll" Exclude="$(TargetPath)" />
+      <InputAssemblies Include="$(OutputPath)*.dll" Exclude="@(MainAssembly)" />
 
       <LibraryPath Include="$(OutputPath)" />
     </ItemGroup>
 
     <ItemGroup>
-      <DoNotInternalizeAssemblies Include="$(TargetPath)" />
+      <DoNotInternalizeAssemblies Include="@(MainAssembly)" />
     </ItemGroup>
 
     <Message Text="Repacking assemblies in $(OutputPath): @(InputAssemblies) ..." Importance="high" />
@@ -32,7 +32,7 @@
     />
 
     <ItemGroup>
-      <FilesToDelete Include="$(OutputPath)*.dll" Exclude="$(TargetPath)" />
+      <FilesToDelete Include="$(OutputPath)*.dll" Exclude="@(MainAssembly)" />
       <FilesToDelete Include="$(OutputPath)*.pdb" Exclude="$(OutputPath)$(TargetName).pdb" />
       <FilesToDelete Include="$(OutputPath)*.deps.json" />
     </ItemGroup>

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -6,7 +6,7 @@
     <Message Text="Repacking $(OutputPath)" Importance="high" />
 
     <ItemGroup>
-      <InputAssemblies Include="$(TargetPath)" />
+      <MainAssembly Include="$(TargetPath)" />
       <InputAssemblies Include="$(OutputPath)*.dll" Exclude="$(TargetPath)" />
 
       <LibraryPath Include="$(OutputPath)" />
@@ -22,7 +22,7 @@
       DebugInfo="true"
       Internalize="true"
       RenameInternalized="false"
-      InputAssemblies="@(InputAssemblies)"
+      InputAssemblies="@(MainAssembly);@(InputAssemblies)"
       InternalizeExclude="@(DoNotInternalizeAssemblies)"
       LibraryPath="@(LibraryPath)"
       TargetKind="SameAsPrimaryAssembly"

--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -16,7 +16,7 @@
       <DoNotInternalizeAssemblies Include="@(MainAssembly)" />
     </ItemGroup>
 
-    <Message Text="Repacking assemblies in $(OutputPath): @(InputAssemblies) ..." Importance="high" />
+    <Message Text="Repacking assemblies in $(OutputPath): @(InputAssemblies->'%(Identity)', ' ') into @(MainAssembly->'%(Identity)')" Importance="high" />
     <ILRepack
       Parallel="true"
       DebugInfo="true"


### PR DESCRIPTION
- **build: split off `$(TargetPath)` from `@(InputAssemblies)` and into `@(MainAssembly)` instead**
- **build: use `@(MainAssembly)` instead of `$(TargetPath)` for clarity**
- **build: improve message before running ILRepack**
