### PR TITLE
build: split off `@(MainAssembly)` from `@(InputAssemblies)` for XmlFormat.MSBuild.Task

### DIFF
--- a/XmlFormat.MsBuild.Task/ILRepack.targets
+++ b/XmlFormat.MsBuild.Task/ILRepack.targets
@@ -16,7 +16,7 @@
       <DoNotInternalizeAssemblies Include="@(MainAssembly)" />
     </ItemGroup>
 
-    <Message Text="Repacking assemblies in $(OutputPath): @(InputAssemblies) ..." Importance="high" />
+    <Message Text="Repacking assemblies in $(OutputPath): @(InputAssemblies->'%(Identity)', ' ') into @(MainAssembly->'%(Identity)')" Importance="high" />
     <ILRepack
       Parallel="true"
       DebugInfo="true"


### PR DESCRIPTION
- **build: split off `$(TargetPath)` from `@(InputAssemblies)` and into `@(MainAssembly)` instead**
- **build: use `@(MainAssembly)` instead of `$(TargetPath)` for clarity**
- **build: improve message before running ILRepack**
