### PR TITLE
build: call `dotnet-ilrepack` in Exec task instead of using ILRepack task for XmlFormat.MSBuild.Task

### DIFF
--- a/XmlFormat.MsBuild.Task/ILRepack.targets
+++ b/XmlFormat.MsBuild.Task/ILRepack.targets
@@ -17,18 +17,33 @@
     </ItemGroup>
 
     <Message Text="Repacking assemblies in $(OutputPath): @(InputAssemblies->'%(Identity)', ' ') into @(MainAssembly->'%(Identity)')" Importance="high" />
-    <ILRepack
-      Parallel="true"
-      DebugInfo="true"
-      Internalize="true"
-      RenameInternalized="false"
-      InputAssemblies="@(MainAssembly);@(InputAssemblies)"
-      InternalizeExclude="@(DoNotInternalizeAssemblies)"
-      LibraryPath="@(LibraryPath)"
-      TargetKind="SameAsPrimaryAssembly"
 
-      OutputFile="$(TargetPath)"
-      LogFile="$(OutputPath)$(AssemblyName).ilrepack.log"
+    <ItemGroup>
+      <_InputAssemblies Include="@(MainAssembly -> '&quot;%(Filename)%(Extension)&quot;')" />
+      <_InputAssemblies Include="@(InputAssemblies -> '&quot;%(Filename)%(Extension)&quot;')" />
+      <_LibraryPaths Include="@(LibraryPath -> '/lib:&quot;%(RelativeDir)&quot;')" />
+    </ItemGroup>
+
+    <PropertyGroup>
+      <_Parallel>/parallel</_Parallel>
+      <_DebugInfo><!-- /ndebug --></_DebugInfo> <!-- remove comment to disable -->
+      <_Verbose>/verbose</_Verbose>
+      <_Internalize>/internalize</_Internalize>
+      <_RenameInternalized><!--/renameinternalized--></_RenameInternalized>
+      <_InternalizeExclude><!-- @(DoNotInternalizeAssemblies->%'(Identity)', ' ') --></_InternalizeExclude>
+      <_TargetKind><!--/target:dll--></_TargetKind>
+
+      <_OutputFile>/out:&quot;$(TargetPath)&quot;</_OutputFile>
+      <_LogFile>/log:&quot;$(OutputPath)$(AssemblyName).ilrepack.log&quot;</_LogFile>
+    </PropertyGroup>
+
+    <Message Text="dotnet ilrepack $(_Parallel) $(_Internalize) $(_RenameInternalized) $(_DebugInfo) $(_Verbose) $(_TargetKind) $(_LogFile) $(_OutputFile) @(_LibraryPaths, ' ') @(_InputAssemblies, ' ')"
+       Importance="high"
+    />
+    <Exec
+      Command="dotnet ilrepack $(_Parallel) $(_Internalize) $(_RenameInternalized) $(_DebugInfo) $(_Verbose) $(_TargetKind) $(_LogFile) $(_OutputFile) @(_LibraryPaths, ' ') @(_InputAssemblies, ' ')"
+      WorkingDirectory="$(OutDir)"
+      ConsoleToMSBuild="True"
     />
 
     <ItemGroup>

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -46,4 +46,6 @@
     <Content Include="$(MSBuildThisFileDirectory)..\XmlFormat.Tool\xmlformat.toml" Link="xmlformat.toml" Pack="true" CopyToOutputDirectory="PreserveNewest" PackagePath="\" />
   </ItemGroup>
 
+  <Import Project="$(MSBuildThisFileDirectory)ILRepack.Config.props" />
+
 </Project>

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -35,7 +35,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" PrivateAssets="all" />
     <PackageReference Include="Alexinea.Extensions.Configuration.Toml" PrivateAssets="all" />
     <PackageReference Include="Superpower" PrivateAssets="all" />
-    <PackageReference Include="ILRepack.Lib.MSBuild.Task" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Label="project references">

--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -47,5 +47,6 @@
   </ItemGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)ILRepack.Config.props" />
+  <Import Project="$(MSBuildThisFileDirectory)ILRepack.targets" />
 
 </Project>


### PR DESCRIPTION
- **build: remove package reference to ILRepack.Lib.MSBuild.Task**
- **build: import ILRepack.Config.props**
- **build: import ILRepack.targets**
- **build: replace `ILReplace` task with `Exec` task calling `dotnet-ilreplace` on the command line**
