### PR TITLE
build: use InputAssemblies from `@(ReferenceCopyLocalPaths)` for XmlFormat.Tool

### DIFF
--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -7,9 +7,9 @@
 
     <ItemGroup>
       <MainAssembly Include="$(TargetPath)" />
-      <InputAssemblies Include="$(OutputPath)*.dll" Exclude="@(MainAssembly)" />
+      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" />
 
-      <LibraryPath Include="$(OutputPath)" />
+      <LibraryPath Include="%(ReferencePathWithRefAssemblies.RelativeDir)" />
     </ItemGroup>
 
     <ItemGroup>

--- a/XmlFormat.Tool/XmlFormat.Tool.csproj
+++ b/XmlFormat.Tool/XmlFormat.Tool.csproj
@@ -11,7 +11,6 @@
     <PackAsTool>true</PackAsTool>
     <PublishRelease>true</PublishRelease>
     <ToolCommandName>xf</ToolCommandName>
-    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Label="build metadata">


### PR DESCRIPTION
- **build: remove setting property CopyLocalLockFileAssemblies**
- **build: use `@(ReferenceCopyLocalPaths)` for InputAssemblies instead of assemblies in `$(OutputPath)`**
