### PR TITLE
build: exclude System assemblies et al. from ILRepack step for XmlFormat.MSBuild.Task

### DIFF
--- a/XmlFormat.MsBuild.Task/ILRepack.targets
+++ b/XmlFormat.MsBuild.Task/ILRepack.targets
@@ -7,7 +7,10 @@
 
     <ItemGroup>
       <MainAssembly Include="$(TargetPath)" />
-      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" />
+
+      <_SystemDependencies Include="@(ReferenceCopyLocalPaths)"
+                           Condition="$([System.String]::new('%(Filename)').StartsWith('System.')) or '%(Filename)' == 'System'" />
+      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" Exclude="@(_SystemDependencies)" />
 
       <LibraryPath Include="%(ReferencePathWithRefAssemblies.RelativeDir)" />
     </ItemGroup>

--- a/XmlFormat.MsBuild.Task/ILRepack.targets
+++ b/XmlFormat.MsBuild.Task/ILRepack.targets
@@ -12,7 +12,9 @@
                            Condition="$([System.String]::new('%(Filename)').StartsWith('System.')) or '%(Filename)' == 'System'" />
       <_MsBuildDependencies Include="@(ReferenceCopyLocalPaths)"
                            Condition="$([System.String]::new('%(Filename)').StartsWith('Microsoft.Build.'))" />
-      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" Exclude="@(_SystemDependencies);@(_MsBuildDependencies)" />
+      <_DotNetDependencies Include="@(ReferenceCopyLocalPaths)"
+                           Condition="$([System.String]::new('%(Filename)').StartsWith('Microsoft.NET.'))" />
+      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" Exclude="@(_SystemDependencies);@(_MsBuildDependencies);@(_DotNetDependencies)" />
 
       <LibraryPath Include="%(ReferencePathWithRefAssemblies.RelativeDir)" />
     </ItemGroup>

--- a/XmlFormat.MsBuild.Task/ILRepack.targets
+++ b/XmlFormat.MsBuild.Task/ILRepack.targets
@@ -10,7 +10,9 @@
 
       <_SystemDependencies Include="@(ReferenceCopyLocalPaths)"
                            Condition="$([System.String]::new('%(Filename)').StartsWith('System.')) or '%(Filename)' == 'System'" />
-      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" Exclude="@(_SystemDependencies)" />
+      <_MsBuildDependencies Include="@(ReferenceCopyLocalPaths)"
+                           Condition="$([System.String]::new('%(Filename)').StartsWith('Microsoft.Build.'))" />
+      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" Exclude="@(_SystemDependencies);@(_MsBuildDependencies)" />
 
       <LibraryPath Include="%(ReferencePathWithRefAssemblies.RelativeDir)" />
     </ItemGroup>

--- a/XmlFormat.MsBuild.Task/ILRepack.targets
+++ b/XmlFormat.MsBuild.Task/ILRepack.targets
@@ -14,7 +14,9 @@
                            Condition="$([System.String]::new('%(Filename)').StartsWith('Microsoft.Build.'))" />
       <_DotNetDependencies Include="@(ReferenceCopyLocalPaths)"
                            Condition="$([System.String]::new('%(Filename)').StartsWith('Microsoft.NET.'))" />
-      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" Exclude="@(_SystemDependencies);@(_MsBuildDependencies);@(_DotNetDependencies)" />
+      <_Win32Dependencies Include="@(ReferenceCopyLocalPaths)"
+                           Condition="$([System.String]::new('%(Filename)').StartsWith('Microsoft.Win32'))" />
+      <InputAssemblies Include="@(ReferenceCopyLocalPaths)" Exclude="@(_SystemDependencies);@(_MsBuildDependencies);@(_DotNetDependencies);@(_Win32Dependencies)" />
 
       <LibraryPath Include="%(ReferencePathWithRefAssemblies.RelativeDir)" />
     </ItemGroup>


### PR DESCRIPTION
- **build: exclude System assemblies from ILRepack inputs**
- **build: exclude MSBuild assemblies from ILRepack inputs**
- **build: exclude .NET assemblies from ILRepack inputs**
- **build: exclude Win32 assemblies from ILRepack inputs**
