### PR TITLE
build: apply ILRepack to intermediate assembly for XmlFormat.Tool

### DIFF
--- a/XmlFormat.Tool/ILRepack.targets
+++ b/XmlFormat.Tool/ILRepack.targets
@@ -30,7 +30,7 @@
       DebugInfo="true"
       Verbose="true"
       Internalize="true"
-      RenameInternalized="true"
+      RenameInternalized="false"
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"
       InternalizeExclude="@(DoNotInternalizeAssemblies)"
       FilterAssemblies="@(FilterAssemblies)"


### PR DESCRIPTION
- **build: run ILRepacker task after target `Compile`**
- **build: remove deleting of merged assemblies**
- **build: adjust paths to use `$(IntermediateOutputPath)` instead of `$(OutputPath)`**
- **build: set RenameInternalized to 'false'**
