### PR TITLE
build: apply ILRepack to intermediate assembly for XmlFormat.MSBuild.Task

### DIFF
--- a/XmlFormat.MsBuild.Task/ILRepack.targets
+++ b/XmlFormat.MsBuild.Task/ILRepack.targets
@@ -3,10 +3,10 @@
 
   <Target Name="ILRepacker" AfterTargets="Compile" DependsOnTargets="ResolveAssemblyReferences">
 
-    <Message Text="Repacking $(OutputPath)" Importance="high" />
+    <Message Text="Repacking $(IntermediateOutputPath)" Importance="high" />
 
     <ItemGroup>
-      <MainAssembly Include="$(TargetPath)" />
+      <MainAssembly Include="$(IntermediateOutputPath)$(TargetFileName)" />
       <InputAssemblies Include="@(ReferenceCopyLocalPaths)" />
 
       <FilterAssemblies Include="Microsoft.Extensions" />
@@ -22,7 +22,7 @@
       <DoNotInternalizeAssemblies Include="@(MainAssembly)" />
     </ItemGroup>
 
-    <Message Text="Repacking assemblies in $(OutputPath): @(InputAssemblies->'%(Identity)', ' ') into @(MainAssembly->'%(Identity)')" Importance="high" />
+    <Message Text="Repacking assemblies in $(IntermediateOutputPath): @(InputAssemblies->'%(Identity)', ' ') into @(MainAssembly->'%(Identity)')" Importance="high" />
 
     <ILRepack
       Parallel="false"
@@ -35,8 +35,8 @@
       InternalizeExclude="@(DoNotInternalizeAssemblies)"
       FilterAssemblies="@(FilterAssemblies)"
 
-      OutputFile="$(TargetPath)"
-      LogFile="$(OutputPath)$(AssemblyName).ilrepack.log"
+      OutputFile="@(MainAssembly)"
+      LogFile="$(IntermediateOutputPath)$(AssemblyName).ilrepack.log"
     />
 
   </Target>

--- a/XmlFormat.MsBuild.Task/ILRepack.targets
+++ b/XmlFormat.MsBuild.Task/ILRepack.targets
@@ -29,7 +29,7 @@
       DebugInfo="true"
       Verbose="true"
       Internalize="true"
-      RenameInternalized="true"
+      RenameInternalized="false"
       InputAssemblies="@(MainAssembly);@(InputAssemblies)"
       LibraryPaths="@(LibraryPath)"
       InternalizeExclude="@(DoNotInternalizeAssemblies)"

--- a/XmlFormat.MsBuild.Task/ILRepack.targets
+++ b/XmlFormat.MsBuild.Task/ILRepack.targets
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <Target Name="ILRepacker" AfterTargets="Build">
+  <Target Name="ILRepacker" AfterTargets="Compile" DependsOnTargets="ResolveAssemblyReferences">
 
     <Message Text="Repacking $(OutputPath)" Importance="high" />
 

--- a/XmlFormat.MsBuild.Task/ILRepack.targets
+++ b/XmlFormat.MsBuild.Task/ILRepack.targets
@@ -39,15 +39,6 @@
       LogFile="$(OutputPath)$(AssemblyName).ilrepack.log"
     />
 
-    <ItemGroup>
-      <FilesToDelete Include="$(OutputPath)*.dll" Exclude="@(MainAssembly)" />
-      <FilesToDelete Include="$(OutputPath)*.pdb" Exclude="$(OutputPath)$(TargetName).pdb" />
-      <FilesToDelete Include="$(OutputPath)*.deps.json" />
-    </ItemGroup>
-
-    <Message Text="Cleaning up merged files: @(FilesToDelete)" Importance="normal" />
-    <Delete Files="@(FilesToDelete)" />
-
   </Target>
 
 </Project>


### PR DESCRIPTION
- **build: run ILRepacker task after target `Compile`**
- **build: remove deletion of merged assemblies**
- **build: adjust paths to use `$(IntermediateOutputPath)` instead of `$(OutputPath)`**
- **build: set RenameInternalized to 'false'**
