### PR TITLE
refactor: change log messages to not rely on interpolated strings in XmlFormat.Tool

### DIFF
--- a/XmlFormat.Tool/Program.cs
+++ b/XmlFormat.Tool/Program.cs
@@ -58,15 +58,14 @@ public class Program
     {
         ILogger logger = loggerFactory.CreateLogger(System.AppDomain.CurrentDomain.FriendlyName);
         logger.LogDebug("options: {}", options);
+        logger.LogDebug("options.FormattingOptions: {}", options.FormattingOptions);
+        logger.LogDebug("options.InputFiles: {}", options.InputFiles);
 
         IConfiguration config = new ConfigurationBuilder()
             .AddTomlFile(Path.Join(AppDomain.CurrentDomain.BaseDirectory, "xmlformat.toml"), optional: false, reloadOnChange: true)
             .AddTomlFile(Path.Join(Environment.CurrentDirectory, ".xmlformat"), optional: true, reloadOnChange: true)
             .AddCommandLine(options.FormattingOptions.ToArray())
             .Build();
-
-        logger.LogDebug($"options.Inline: {options.Inline}");
-        logger.LogDebug($"options.InputFiles: {options.InputFiles} {{ {string.Join(", ", options.InputFiles)} }}");
 
         FormattingOptions formattingOptions = new();
         config.Bind(formattingOptions);

--- a/XmlFormat.Tool/Program.cs
+++ b/XmlFormat.Tool/Program.cs
@@ -46,7 +46,7 @@ public class Program
     public static void Main(string[] args)
     {
         ILogger logger = loggerFactory.CreateLogger(System.AppDomain.CurrentDomain.FriendlyName);
-        logger.LogDebug($"running with args: {string.Join(" ", args)}");
+        logger.LogDebug("running with args: {}", args);
 
         CommandLine
             .Parser.Default.ParseArguments<Options>(args) //
@@ -57,7 +57,7 @@ public class Program
     static void RunOptions(Options options)
     {
         ILogger logger = loggerFactory.CreateLogger(System.AppDomain.CurrentDomain.FriendlyName);
-        logger.LogDebug($"options: {options}");
+        logger.LogDebug("options: {}", options);
 
         IConfiguration config = new ConfigurationBuilder()
             .AddTomlFile(Path.Join(AppDomain.CurrentDomain.BaseDirectory, "xmlformat.toml"), optional: false, reloadOnChange: true)
@@ -70,20 +70,20 @@ public class Program
 
         FormattingOptions formattingOptions = new();
         config.Bind(formattingOptions);
-        logger.LogDebug($"formattingOptions: {formattingOptions}");
+        logger.LogDebug("formatting options: {}", formattingOptions);
 
         foreach (var inputFile in options.InputFiles!)
         {
             FormattingOptions actualFormattingOptions = formattingOptions with { };
             string? profile = options.Profile ?? Path.GetExtension(inputFile)?.Trim('.');
-            logger.LogDebug($"profile: {profile}");
+            logger.LogDebug("formatting profile: {}", profile);
 
             if (!string.IsNullOrEmpty(profile))
             {
                 var configSection = config.GetSection(profile);
                 configSection.Bind(actualFormattingOptions);
             }
-            logger.LogDebug($"actual formattingOptions: {actualFormattingOptions}");
+            logger.LogDebug("actual formattingOptions: {}", actualFormattingOptions);
 
             using (Stream istream = OpenInputStreamOrStdIn(inputFile, options.Inline))
             using (Stream ostream = OpenOutputStreamOrStdOut(inputFile, options.Inline))


### PR DESCRIPTION
- **refactor: change log messages to not rely on interpolated strings**
- **refactor: gather debug logs**
