### PR TITLE
fix: format single-word elements on one line

### DIFF
--- a/Tests/SAX.Formatter.Test/FormatterTest.cs
+++ b/Tests/SAX.Formatter.Test/FormatterTest.cs
@@ -24,8 +24,8 @@ public class FormatterTest
     [InlineData("<element/> ", "<element />")]
     [InlineData("<element /> ", "<element />")]
     [InlineData("<element attribute=\"1\"/> ", "<element attribute=\"1\" />")]
-    [InlineData("<element>test</element> ", "<element>\ntest\n</element>")]
-    [InlineData("<element attribute=\"1\">test</element> ", "<element attribute=\"1\">\ntest\n</element>")]
+    [InlineData("<element>test</element> ", "<element>test</element>")]
+    [InlineData("<element attribute=\"1\">test</element> ", "<element attribute=\"1\">test</element>")]
     public void IdentityTest(string input, string expected)
     {
         var formatted = XmlFormat.XmlFormat.Format(input, new FormattingOptions(80, "", 1, 2));
@@ -60,8 +60,8 @@ public class FormatterTest
     [InlineData("<element/> ", "<element />")]
     [InlineData("<element /> ", "<element />")]
     [InlineData("<element attribute=\"1\"/> ", "<element attribute=\"1\" />")]
-    [InlineData("<element>test</element> ", "<element>\ntest\n</element>")]
-    [InlineData("<element attribute=\"1\">test</element> ", "<element attribute=\"1\">\ntest\n</element>")]
+    [InlineData("<element>test</element> ", "<element>test</element>")]
+    [InlineData("<element attribute=\"1\">test</element> ", "<element attribute=\"1\">test</element>")]
     public void IdentityTestStream(string input, string expected)
     {
         Encoding encoding = new UTF8Encoding(true);

--- a/Tests/SAX.Formatter.Test/FormatterTest.cs
+++ b/Tests/SAX.Formatter.Test/FormatterTest.cs
@@ -25,7 +25,9 @@ public class FormatterTest
     [InlineData("<element /> ", "<element />")]
     [InlineData("<element attribute=\"1\"/> ", "<element attribute=\"1\" />")]
     [InlineData("<element>test</element> ", "<element>test</element>")]
+    [InlineData("<element>test test</element> ", "<element>\ntest test\n</element>")]
     [InlineData("<element attribute=\"1\">test</element> ", "<element attribute=\"1\">test</element>")]
+    [InlineData("<element attribute=\"1\">test test</element> ", "<element attribute=\"1\">\ntest test\n</element>")]
     public void IdentityTest(string input, string expected)
     {
         var formatted = XmlFormat.XmlFormat.Format(input, new FormattingOptions(80, "", 1, 2));
@@ -61,7 +63,9 @@ public class FormatterTest
     [InlineData("<element /> ", "<element />")]
     [InlineData("<element attribute=\"1\"/> ", "<element attribute=\"1\" />")]
     [InlineData("<element>test</element> ", "<element>test</element>")]
+    [InlineData("<element>test test</element> ", "<element>\ntest test\n</element>")]
     [InlineData("<element attribute=\"1\">test</element> ", "<element attribute=\"1\">test</element>")]
+    [InlineData("<element attribute=\"1\">test test</element> ", "<element attribute=\"1\">\ntest test\n</element>")]
     public void IdentityTestStream(string input, string expected)
     {
         Encoding encoding = new UTF8Encoding(true);

--- a/Tests/XmlFormat.Test.Assets/idtest.xml
+++ b/Tests/XmlFormat.Test.Assets/idtest.xml
@@ -21,9 +21,7 @@
   </StackPanel>
   <EmptyElement />
   <Foobar Hoge="True" />
-  <InlineContents>
-    contents
-  </InlineContents>
+  <InlineContents>contents</InlineContents>
   <PocketMonsters
     Alligatorade="Water"
     Capybarista="Psycho"
@@ -39,6 +37,7 @@
     ]]>
   </Code>
   <?php print("Hello, World!"); ?>
+
   <!--
     Far out in the uncharted backwaters of the unfashionable end of the west-
 ern spiral arm of the Galaxy lies a small unregarded yellow sun. Orbiting
@@ -93,11 +92,11 @@ It begins with a house.
   -->
   <LongText>
     First, it is slightly cheaper; and secondly it has the words Don’t Panic
-inscribed in large friendly letters on its cover.
-But the story of this terrible, stupid Thursday, the story of its extraordinary
-consequences, and the story of how these consequences are inextricably
-intertwined with this remarkable book begins very simply.
-It begins with a house.
+    inscribed in large friendly letters on its cover.
+    But the story of this terrible, stupid Thursday, the story of its extraordinary
+    consequences, and the story of how these consequences are inextricably
+    intertwined with this remarkable book begins very simply.
+    It begins with a house.
   </LongText>
   <![CDATA[
 <xml>

--- a/XmlFormat/FormattingXmlReadHandler.cs
+++ b/XmlFormat/FormattingXmlReadHandler.cs
@@ -237,7 +237,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         }
 
         textWriter.Indent--;
-        textWriter.WriteLine(">");
+        textWriter.Write(">");
         textWriter.Flush();
         textWriter.Indent++;
     }

--- a/XmlFormat/FormattingXmlReadHandler.cs
+++ b/XmlFormat/FormattingXmlReadHandler.cs
@@ -2,6 +2,7 @@ using System;
 using System.CodeDom.Compiler;
 using System.Linq;
 using System.Text;
+using Microsoft.Toolkit.HighPerformance;
 
 namespace XmlFormat;
 
@@ -358,7 +359,8 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
             if (textWriter.Indent > 0)
                 textWriter.WriteLine();
 
-            textWriter.WriteLine(extraTrimText.ToString());
+            foreach (var token in extraTrimText.Tokenize('\n'))
+                textWriter.WriteLine(token.Trim().ToString());
         }
 
         // eat trailing newlines

--- a/XmlFormat/FormattingXmlReadHandler.cs
+++ b/XmlFormat/FormattingXmlReadHandler.cs
@@ -355,7 +355,9 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         }
         else
         {
-            textWriter.WriteLine();
+            if (textWriter.Indent > 0)
+                textWriter.WriteLine();
+
             textWriter.WriteLine(extraTrimText.ToString());
         }
 

--- a/XmlFormat/FormattingXmlReadHandler.cs
+++ b/XmlFormat/FormattingXmlReadHandler.cs
@@ -348,7 +348,16 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         for (int i = 0; i < Math.Min(leadingNewlines - 1, Options.MaxEmptyLines); i++)
             textWriter.WriteLineNoTabs();
 
-        textWriter.WriteLine(trimText.Trim().ToString());
+        var extraTrimText = trimText.Trim();
+        if (extraTrimText.None(x => Char.IsWhiteSpace(x)))
+        {
+            textWriter.Write(extraTrimText.ToString());
+        }
+        else
+        {
+            textWriter.WriteLine();
+            textWriter.WriteLine(extraTrimText.ToString());
+        }
 
         // eat trailing newlines
         // note: due to textWriter.WriteLine() above, we have to discount 1 trailing newline

--- a/XmlFormat/FormattingXmlReadHandler.cs
+++ b/XmlFormat/FormattingXmlReadHandler.cs
@@ -379,6 +379,9 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
     /// <param name="column">The column number where the comment appears.</param>
     public override void OnComment(ReadOnlySpan<char> comment, int line, int column)
     {
+        if (textWriter.Indent > 0)
+            textWriter.WriteLine();
+
         if (comment.Length < Options.LineLength)
         {
             textWriter.WriteLine($"<!-- {comment.Trim().ToString()} -->");

--- a/XmlFormat/IndentedTextWriterExtension.cs
+++ b/XmlFormat/IndentedTextWriterExtension.cs
@@ -14,7 +14,7 @@ public static class IndentedTextWriterExtension
         writer.Indent = indent;
     }
 
-    public static void WriteLine(this IndentedTextWriter writer) => writer.WriteLineNoTabs("");
+    public static void WriteLine(this IndentedTextWriter writer) => writer.WriteLine("");
 
     public static void WriteLineNoTabs(this IndentedTextWriter writer) => writer.WriteLineNoTabs("");
 }


### PR DESCRIPTION
- **refactor: do not add new line after closing element start tag**
- **refactor: write single word text inline, multiple word text by inserting new line before and after**
- **fix: only write line break before multi-word text if indenting**
- **refactor: write multi-line text with fitting indentation**
- **fix: write line break before comment text if indenting**
- **refactor: implement proper handling of line break after element start**
- **fix: adjust idtest.xml to expected formatting results**
- **fix: adjust unit tests to expected results in SAX.Formatter.Test**
- **feat: unit test cases for multi-word text inside element to SAX.Formatter.Test**
- **refactor: redirect IndentedTextWriter.WriteLine() to .WriteLine("")**
