### PR TITLE
refactor: handle inline text before multi-line text

### DIFF
--- a/Tests/SAX.Formatter.Test/FormatterTest.cs
+++ b/Tests/SAX.Formatter.Test/FormatterTest.cs
@@ -25,9 +25,9 @@ public class FormatterTest
     [InlineData("<element /> ", "<element />")]
     [InlineData("<element attribute=\"1\"/> ", "<element attribute=\"1\" />")]
     [InlineData("<element>test</element> ", "<element>test</element>")]
-    [InlineData("<element>test test</element> ", "<element>\ntest test\n</element>")]
+    [InlineData("<element>test test</element> ", "<element>test test</element>")]
     [InlineData("<element attribute=\"1\">test</element> ", "<element attribute=\"1\">test</element>")]
-    [InlineData("<element attribute=\"1\">test test</element> ", "<element attribute=\"1\">\ntest test\n</element>")]
+    [InlineData("<element attribute=\"1\">test test</element> ", "<element attribute=\"1\">test test</element>")]
     public void IdentityTest(string input, string expected)
     {
         var formatted = XmlFormat.XmlFormat.Format(input, new FormattingOptions(80, "", 1, 2));
@@ -63,9 +63,9 @@ public class FormatterTest
     [InlineData("<element /> ", "<element />")]
     [InlineData("<element attribute=\"1\"/> ", "<element attribute=\"1\" />")]
     [InlineData("<element>test</element> ", "<element>test</element>")]
-    [InlineData("<element>test test</element> ", "<element>\ntest test\n</element>")]
+    [InlineData("<element>test test</element> ", "<element>test test</element>")]
     [InlineData("<element attribute=\"1\">test</element> ", "<element attribute=\"1\">test</element>")]
-    [InlineData("<element attribute=\"1\">test test</element> ", "<element attribute=\"1\">\ntest test\n</element>")]
+    [InlineData("<element attribute=\"1\">test test</element> ", "<element attribute=\"1\">test test</element>")]
     public void IdentityTestStream(string input, string expected)
     {
         Encoding encoding = new UTF8Encoding(true);

--- a/Tests/SAX.Formatter.Test/FormatterTest.cs
+++ b/Tests/SAX.Formatter.Test/FormatterTest.cs
@@ -24,10 +24,18 @@ public class FormatterTest
     [InlineData("<element/> ", "<element />")]
     [InlineData("<element /> ", "<element />")]
     [InlineData("<element attribute=\"1\"/> ", "<element attribute=\"1\" />")]
+    [InlineData("<element></element> ", "<element></element>")]
+    [InlineData("<element>\n</element> ", "<element>\n</element>")]
     [InlineData("<element>test</element> ", "<element>test</element>")]
     [InlineData("<element>test test</element> ", "<element>test test</element>")]
+    [InlineData("<element>test test test</element> ", "<element>test test test</element>")]
+    [InlineData("<element>test\ntest</element> ", "<element>\ntest\ntest\n</element>")]
+    [InlineData("<element attribute=\"1\"></element> ", "<element attribute=\"1\"></element>")]
+    [InlineData("<element attribute=\"1\">\n</element> ", "<element attribute=\"1\">\n</element>")]
     [InlineData("<element attribute=\"1\">test</element> ", "<element attribute=\"1\">test</element>")]
     [InlineData("<element attribute=\"1\">test test</element> ", "<element attribute=\"1\">test test</element>")]
+    [InlineData("<element attribute=\"1\">test test test</element> ", "<element attribute=\"1\">test test test</element>")]
+    [InlineData("<element attribute=\"1\">test\ntest</element> ", "<element attribute=\"1\">\ntest\ntest\n</element>")]
     public void IdentityTest(string input, string expected)
     {
         var formatted = XmlFormat.XmlFormat.Format(input, new FormattingOptions(80, "", 1, 2));
@@ -62,10 +70,18 @@ public class FormatterTest
     [InlineData("<element/> ", "<element />")]
     [InlineData("<element /> ", "<element />")]
     [InlineData("<element attribute=\"1\"/> ", "<element attribute=\"1\" />")]
+    [InlineData("<element></element> ", "<element></element>")]
+    [InlineData("<element>\n</element> ", "<element>\n</element>")]
     [InlineData("<element>test</element> ", "<element>test</element>")]
     [InlineData("<element>test test</element> ", "<element>test test</element>")]
+    [InlineData("<element>test test test</element> ", "<element>test test test</element>")]
+    [InlineData("<element>test\ntest</element> ", "<element>\ntest\ntest\n</element>")]
+    [InlineData("<element attribute=\"1\"></element> ", "<element attribute=\"1\"></element>")]
+    [InlineData("<element attribute=\"1\">\n</element> ", "<element attribute=\"1\">\n</element>")]
     [InlineData("<element attribute=\"1\">test</element> ", "<element attribute=\"1\">test</element>")]
     [InlineData("<element attribute=\"1\">test test</element> ", "<element attribute=\"1\">test test</element>")]
+    [InlineData("<element attribute=\"1\">test test test</element> ", "<element attribute=\"1\">test test test</element>")]
+    [InlineData("<element attribute=\"1\">test\ntest</element> ", "<element attribute=\"1\">\ntest\ntest\n</element>")]
     public void IdentityTestStream(string input, string expected)
     {
         Encoding encoding = new UTF8Encoding(true);

--- a/Tests/XmlFormat.Test.Assets/idtest.xml
+++ b/Tests/XmlFormat.Test.Assets/idtest.xml
@@ -19,9 +19,13 @@
   <StackPanel>
     <DataGrid AutoGenerateColumns="True" ItemsSource="{CompiledBinding Commits}" />
   </StackPanel>
+
   <EmptyElement />
+
   <Foobar Hoge="True" />
+
   <InlineContents>contents</InlineContents>
+
   <PocketMonsters
     Alligatorade="Water"
     Capybarista="Psycho"
@@ -90,6 +94,7 @@ consequences, and the story of how these consequences are inextricably
 intertwined with this remarkable book begins very simply.
 It begins with a house.
   -->
+
   <LongText>
     First, it is slightly cheaper; and secondly it has the words Don’t Panic
     inscribed in large friendly letters on its cover.
@@ -98,6 +103,7 @@ It begins with a house.
     intertwined with this remarkable book begins very simply.
     It begins with a house.
   </LongText>
+
   <![CDATA[
 <xml>
   ]]>
@@ -105,6 +111,7 @@ It begins with a house.
   <xml>
   </xml>
   ]]>
+
 </Window>
 <!-- <Xml>
   foobar

--- a/XmlFormat/FormattingXmlReadHandler.cs
+++ b/XmlFormat/FormattingXmlReadHandler.cs
@@ -333,6 +333,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
     {
         var trimmedTextExceptNewLines = text.Trim(c => char.IsWhiteSpace(c) && c != '\n');
         var fullyTrimmedText = trimmedTextExceptNewLines.Trim();
+        int leadingWhitespace = textWriter.Indent * Options.Tabs.Length * Options.TabsRepeat;
 
         if (trimmedTextExceptNewLines.IsEmpty)
         {
@@ -358,8 +359,6 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         // eat leading newlines
         for (int i = 0; i < Math.Min(leadingNewlines - 1, Options.MaxEmptyLines); i++)
             textWriter.WriteLineNoTabs();
-
-        int leadingWhitespace = textWriter.Indent * Options.Tabs.Length * Options.TabsRepeat;
 
         if (
             fullyTrimmedText.Length < Options.LineLength - leadingWhitespace

--- a/XmlFormat/FormattingXmlReadHandler.cs
+++ b/XmlFormat/FormattingXmlReadHandler.cs
@@ -332,6 +332,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
     public override void OnText(ReadOnlySpan<char> text, int line, int column)
     {
         var trimmedTextExceptNewLines = text.Trim(c => char.IsWhiteSpace(c) && c != '\n');
+        var fullyTrimmedText = trimmedTextExceptNewLines.Trim();
 
         if (trimmedTextExceptNewLines.IsEmpty)
         {
@@ -359,7 +360,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
             textWriter.WriteLineNoTabs();
 
         int leadingWhitespace = textWriter.Indent * Options.Tabs.Length * Options.TabsRepeat;
-        var fullyTrimmedText = trimmedTextExceptNewLines.Trim();
+
         if (
             fullyTrimmedText.Length < Options.LineLength - leadingWhitespace
             && fullyTrimmedText.None(c => c == '\n')

--- a/XmlFormat/FormattingXmlReadHandler.cs
+++ b/XmlFormat/FormattingXmlReadHandler.cs
@@ -359,20 +359,20 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
             textWriter.WriteLineNoTabs();
 
         int leadingWhitespace = textWriter.Indent * Options.Tabs.Length * Options.TabsRepeat;
-        var extraTrimText = trimmedTextExceptNewLines.Trim();
+        var fullyTrimmedText = trimmedTextExceptNewLines.Trim();
         if (
-            extraTrimText.Length < Options.LineLength - leadingWhitespace
-            && extraTrimText.None(c => c == '\n')
+            fullyTrimmedText.Length < Options.LineLength - leadingWhitespace
+            && fullyTrimmedText.None(c => c == '\n')
         )
         {
-            textWriter.Write(extraTrimText.ToString());
+            textWriter.Write(fullyTrimmedText.ToString());
             unhandledNewLineAfterElementStart = false;
         }
         else
         {
             HandleNewLineAfterElementStart();
 
-            foreach (var token in extraTrimText.Tokenize('\n'))
+            foreach (var token in fullyTrimmedText.Tokenize('\n'))
                 textWriter.WriteLine(token.Trim().ToString());
         }
 

--- a/XmlFormat/FormattingXmlReadHandler.cs
+++ b/XmlFormat/FormattingXmlReadHandler.cs
@@ -331,9 +331,9 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
     /// <param name="column">The column number where the text starts.</param>
     public override void OnText(ReadOnlySpan<char> text, int line, int column)
     {
-        var trimText = text.Trim(c => char.IsWhiteSpace(c) && c != '\n');
+        var trimmedTextExceptNewLines = text.Trim(c => char.IsWhiteSpace(c) && c != '\n');
 
-        if (trimText.IsEmpty)
+        if (trimmedTextExceptNewLines.IsEmpty)
         {
             unhandledNewLineAfterElementStart = false; //< allows empty inline elements `<element></element>`
             // alternative:
@@ -341,12 +341,12 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
             return;
         }
 
-        int totalNewlines = trimText.Count(c => c == '\n');
-        int leadingNewlines = trimText.CountStart(c => c == '\n');
-        int trailingNewlines = trimText.CountEnd(c => c == '\n');
+        int totalNewlines = trimmedTextExceptNewLines.Count(c => c == '\n');
+        int leadingNewlines = trimmedTextExceptNewLines.CountStart(c => c == '\n');
+        int trailingNewlines = trimmedTextExceptNewLines.CountEnd(c => c == '\n');
 
         // eat newlines: text is just newlines, and reduce any amount of newlines to max 2
-        if (trimText.IsWhiteSpace())
+        if (trimmedTextExceptNewLines.IsWhiteSpace())
         {
             for (int i = 0; i < Math.Min(totalNewlines - 1, Options.MaxEmptyLines); i++)
                 textWriter.WriteLineNoTabs();
@@ -359,7 +359,7 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
             textWriter.WriteLineNoTabs();
 
         int leadingWhitespace = textWriter.Indent * Options.Tabs.Length * Options.TabsRepeat;
-        var extraTrimText = trimText.Trim();
+        var extraTrimText = trimmedTextExceptNewLines.Trim();
         if (
             extraTrimText.Length < Options.LineLength - leadingWhitespace
             && extraTrimText.None(c => c == '\n')

--- a/XmlFormat/FormattingXmlReadHandler.cs
+++ b/XmlFormat/FormattingXmlReadHandler.cs
@@ -343,6 +343,17 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
             return;
         }
 
+        if (
+            !fullyTrimmedText.IsEmpty
+            && fullyTrimmedText.None(c => c == '\n')
+            && fullyTrimmedText.Length < Options.LineLength - leadingWhitespace
+        )
+        {
+            textWriter.Write(fullyTrimmedText.ToString());
+            unhandledNewLineAfterElementStart = false;
+            return;
+        }
+
         int totalNewlines = trimmedTextExceptNewLines.Count(c => c == '\n');
         int leadingNewlines = trimmedTextExceptNewLines.CountStart(c => c == '\n');
         int trailingNewlines = trimmedTextExceptNewLines.CountEnd(c => c == '\n');
@@ -360,21 +371,10 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         for (int i = 0; i < Math.Min(leadingNewlines - 1, Options.MaxEmptyLines); i++)
             textWriter.WriteLineNoTabs();
 
-        if (
-            fullyTrimmedText.Length < Options.LineLength - leadingWhitespace
-            && fullyTrimmedText.None(c => c == '\n')
-        )
-        {
-            textWriter.Write(fullyTrimmedText.ToString());
-            unhandledNewLineAfterElementStart = false;
-        }
-        else
-        {
-            HandleNewLineAfterElementStart();
+        HandleNewLineAfterElementStart();
 
-            foreach (var token in fullyTrimmedText.Tokenize('\n'))
-                textWriter.WriteLine(token.Trim().ToString());
-        }
+        foreach (var token in fullyTrimmedText.Tokenize('\n'))
+            textWriter.WriteLine(token.Trim().ToString());
 
         // eat trailing newlines
         // note: due to textWriter.WriteLine() above, we have to discount 1 trailing newline

--- a/XmlFormat/FormattingXmlReadHandler.cs
+++ b/XmlFormat/FormattingXmlReadHandler.cs
@@ -354,6 +354,8 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
             return;
         }
 
+        HandleNewLineAfterElementStart();
+
         int totalNewlines = trimmedTextExceptNewLines.Count(c => c == '\n');
         int leadingNewlines = trimmedTextExceptNewLines.CountStart(c => c == '\n');
         int trailingNewlines = trimmedTextExceptNewLines.CountEnd(c => c == '\n');
@@ -370,8 +372,6 @@ public class FormattingXmlReadHandler : XmlReadHandlerBase
         // eat leading newlines
         for (int i = 0; i < Math.Min(leadingNewlines - 1, Options.MaxEmptyLines); i++)
             textWriter.WriteLineNoTabs();
-
-        HandleNewLineAfterElementStart();
 
         foreach (var token in fullyTrimmedText.Tokenize('\n'))
             textWriter.WriteLine(token.Trim().ToString());


### PR DESCRIPTION
- **refactor: rename variable `trimText` -> `trimmedTextExceptNewLines`**
- **refactor: rename variable `extraTrimText` -> `fullyTrimmedText`**
- **refactor: move declaration of `fullyTrimmedText` to function top**
- **refactor: move declaration of `leadingWhitespace` to function top**
- **refactor: handle inline text before multi-line text**
- **refactor: handle new line after element start before handling other line breaks**
- **fix: adjust unit tests to expected results in SAX.Formatter.Test**
- **feat: add more unit test cases for multi-word text inside element to SAX.Formatter.Test**
- **refactor: add linebreaks between elements in idtest.xml**
