### PR TITLE
build: remove obsolete package reference to ILRepack.Lib.MSBuild.Task v2.0.43

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -24,7 +24,6 @@
   <ItemGroup Label="build dependencies">
     <PackageVersion Include="Costura.Fody" Version="6.0.0" />
     <PackageVersion Include="Fody" Version="6.9.2" />
-    <PackageVersion Include="ILRepack.Lib.MSBuild.Task" Version="2.0.43" />
   </ItemGroup>
 
   <ItemGroup Label="unit test dependencies">


### PR DESCRIPTION
reason: superseded by global package reference to KageKirin.ILRepack.Tool.MSBuild.Task
