### PR TITLE
build: use 'KageKirin.ILRepack.Tool.MSBuild.Task' instead of 'KageKirin.ILRepack.Lib.MSBuild.Task'

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -46,7 +46,7 @@
     <!-- structured build logger -->
     <GlobalPackageReference Include="MSBuild.StructuredLogger" Version="2.3.17" PrivateAssets="All" />
     <!-- ILRepack -->
-    <GlobalPackageReference Include="KageKirin.ILRepack.Lib.MSBuild.Task" Version="0.4.0" PrivateAssets="All" />
+    <GlobalPackageReference Include="KageKirin.ILRepack.Tool.MSBuild.Task" Version="0.4.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
reason: stability, the former has it, the latter lacks it.
