### PR TITLE
build: change assembly name to XmlFormat.MSBuild.Task

### DIFF
--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <AssemblyName>XmlFormat.MsBuild.Task</AssemblyName>
+    <AssemblyName>XmlFormat.MSBuild.Task</AssemblyName>
     <IsPackable>true</IsPackable>
     <IsPublishable>true</IsPublishable>
     <PackRelease>true</PackRelease>

--- a/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
+++ b/XmlFormat.MsBuild.Task/build/KageKirin.XmlFormat.MSBuild.Task.targets
@@ -3,7 +3,7 @@
 
   <!-- Declare the pass to the MSBuild assembly as variable -->
   <PropertyGroup>
-    <XmlFormatAssembly>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\XmlFormat.MsBuild.Task.dll</XmlFormatAssembly>
+    <XmlFormatAssembly>$(MSBuildThisFileDirectory)..\lib\netstandard2.0\XmlFormat.MSBuild.Task.dll</XmlFormatAssembly>
   </PropertyGroup>
 
   <!-- Select TaskFactory class depending on MSBuild version -->


### PR DESCRIPTION
note: 'MSBuild' instead of 'MsBuild'
reason: simpler format
