### PR TITLE
build: enable DevelopmentDependency flag

### DIFF
--- a/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
+++ b/XmlFormat.MsBuild.Task/XmlFormat.MsBuild.Task.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <DevelopmentDependency>true</DevelopmentDependency>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>XmlFormat.MSBuild.Task</AssemblyName>


### PR DESCRIPTION
rationale: referencing this package will not link the assembly
