### PR TITLE
build: bump package references

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
-    <PackageVersion Include="xunit.v3.assert" Version="3.0.0" />
+    <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.8.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,7 +44,7 @@
     <!-- enable automatic versioning -->
     <GlobalPackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
     <!-- structured build logger -->
-    <GlobalPackageReference Include="MSBuild.StructuredLogger" Version="2.3.17" PrivateAssets="All" />
+    <GlobalPackageReference Include="MSBuild.StructuredLogger" Version="2.3.178" PrivateAssets="All" />
     <!-- ILRepack -->
     <GlobalPackageReference Include="KageKirin.ILRepack.Tool.MSBuild.Task" Version="0.4.0" PrivateAssets="All" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup Label="functionality dependencies">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.8.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.7" />
     <PackageVersion Include="Alexinea.Extensions.Configuration.Toml" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.7" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.7" />
     <PackageVersion Include="Alexinea.Extensions.Configuration.Toml" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <PackageVersion Include="Alexinea.Extensions.Configuration.Toml" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.7" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.8.0" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup Label="build dependencies">
-    <PackageVersion Include="Costura.Fody" Version="6.0.0" />
+    <PackageVersion Include="Costura.Fody" Version="6.1.0" />
     <PackageVersion Include="Fody" Version="6.9.2" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
 
   <ItemGroup Label="unit test dependencies">
     <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="xunit.v3" Version="3.0.0" />
     <PackageVersion Include="xunit.v3.assert" Version="3.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,7 +33,7 @@
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.8.0" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.2" />
   </ItemGroup>
 
   <ItemGroup Label="global package references">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,7 +40,7 @@
     <!-- enable reproducible builds -->
     <GlobalPackageReference Include="DotNet.ReproducibleBuilds" Version="2.0.2" PrivateAssets="All" />
     <!-- enable source link -->
-    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+    <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
     <!-- enable automatic versioning -->
     <GlobalPackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
     <!-- structured build logger -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
   <ItemGroup Label="unit test dependencies">
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageVersion Include="xunit.v3" Version="3.0.0" />
+    <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.assert" Version="3.0.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.3" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,7 +1,7 @@
 <Project>
 
   <ItemGroup Label="hosting dependencies">
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.7" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
   <ItemGroup Label="hosting dependencies">
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.7" />
     <PackageVersion Include="Alexinea.Extensions.Configuration.Toml" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.7" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,7 +2,7 @@
 
   <ItemGroup Label="hosting dependencies">
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="9.0.7" />
     <PackageVersion Include="Alexinea.Extensions.Configuration.Toml" Version="7.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,7 +42,7 @@
     <!-- enable source link -->
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.203" PrivateAssets="All" />
     <!-- enable automatic versioning -->
-    <GlobalPackageReference Include="MinVer" Version="6.0.0" PrivateAssets="All" />
+    <GlobalPackageReference Include="MinVer" Version="7.0.0" PrivateAssets="All" />
     <!-- structured build logger -->
     <GlobalPackageReference Include="MSBuild.StructuredLogger" Version="2.3.17" PrivateAssets="All" />
     <!-- ILRepack -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,7 +38,7 @@
 
   <ItemGroup Label="global package references">
     <!-- enable reproducible builds -->
-    <GlobalPackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25" PrivateAssets="All" />
+    <GlobalPackageReference Include="DotNet.ReproducibleBuilds" Version="2.0.2" PrivateAssets="All" />
     <!-- enable source link -->
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <!-- enable automatic versioning -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.CommandLine" Version="10.0.7" />
     <PackageVersion Include="Alexinea.Extensions.Configuration.Toml" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.7" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="9.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="9.0.7" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
-    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.14.8" />
+    <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="17.14.8" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -18,7 +18,7 @@
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.4.0" />
-    <PackageVersion Include="Microsoft.Build.Framework" Version="17.14.8" />
+    <PackageVersion Include="Microsoft.Build.Framework" Version="18.4.0" />
   </ItemGroup>
 
   <ItemGroup Label="build dependencies">

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup Label="functionality dependencies">
-    <PackageVersion Include="Superpower" Version="3.1.0" />
+    <PackageVersion Include="Superpower" Version="3.2.1" />
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="System.Memory" Version="4.6.3" />
     <PackageVersion Include="Microsoft.Toolkit.HighPerformance" Version="7.1.2" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -23,7 +23,7 @@
 
   <ItemGroup Label="build dependencies">
     <PackageVersion Include="Costura.Fody" Version="6.1.0" />
-    <PackageVersion Include="Fody" Version="6.9.2" />
+    <PackageVersion Include="Fody" Version="6.9.3" />
   </ItemGroup>
 
   <ItemGroup Label="unit test dependencies">


### PR DESCRIPTION
- **build: bump package reference Microsoft.Extensions.Configuration to v10.0.7**
- **build: bump package reference Microsoft.Extensions.Configuration.Abstractions to v10.0.7**
- **build: bump package reference Microsoft.Extensions.Configuration.Binder to v10.0.7**
- **build: bump package reference Microsoft.Extensions.Configuration.CommandLine to v10.0.7**
- **build: bump package reference Microsoft.Extensions.Logging to v10.0.7**
- **build: bump package reference Microsoft.Extensions.Logging.Abstractions to v10.0.7**
- **build: bump package reference Microsoft.Extensions.Logging.Console to v10.0.7**
- **build: bump package reference Microsoft.Extensions.Logging.Debug to v10.0.7**
- **build: bump package reference Superpower to v3.2.1**
- **build: bump package reference Microsoft.Build.Utilities.Core to v18.4.0**
- **build: bump package reference Microsoft.Build.Framework to v18.4.0**
- **build: bump package reference Costura.Fody to v6.1.0**
- **build: bump package reference Fody to v6.9.3**
- **build: bump package reference Microsoft.NET.Test.Sdk to v18.5.1**
- **build: bump package reference xunit.v3 to v3.2.2**
- **build: bump package reference xunit.v3.assert to v3.2.2**
- **build: bump package reference xunit.runner.visualstudio to v3.1.5**
- **build: bump package reference Microsoft.Testing.Extensions.CodeCoverage to v18.6.2**
- **build: bump package reference Microsoft.Testing.Extensions.TrxReport to v2.2.2**
- **build: bump global package reference DotNet.ReproducibleBuilds to v2.0.2**
- **build: bump global package reference Microsoft.SourceLink.GitHub to v10.0.203**
- **build: bump global package reference MinVer to v7.0.0**
- **build: bump global package reference MSBuild.StructuredLogger to v2.3.178**
