### PR TITLE
build: replace package reference 'xunit.v3' with 'xunit.v3.mtp-v2'

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
   <ItemGroup Label="unit test dependencies">
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageVersion Include="xunit.v3" Version="3.2.2" />
+    <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
     <PackageVersion Include="xunit.v3.assert" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.6.2" />

--- a/Tests/MsBuild.Task.Test/MsBuild.Task.Test.csproj
+++ b/Tests/MsBuild.Task.Test/MsBuild.Task.Test.csproj
@@ -39,7 +39,7 @@
     <PackageReference Include="Microsoft.Build.Utilities.Core" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />

--- a/Tests/ReadOnlySpan.Extensions.Test/ReadOnlySpan.Extensions.Test.csproj
+++ b/Tests/ReadOnlySpan.Extensions.Test/ReadOnlySpan.Extensions.Test.csproj
@@ -37,7 +37,7 @@
 
     <ItemGroup Label="package dependencies">
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />

--- a/Tests/SAX.EventHandler.Test/SAX.EventHandler.Test.csproj
+++ b/Tests/SAX.EventHandler.Test/SAX.EventHandler.Test.csproj
@@ -37,7 +37,7 @@
 
     <ItemGroup Label="package dependencies">
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />

--- a/Tests/SAX.Formatter.Test/SAX.Formatter.Test.csproj
+++ b/Tests/SAX.Formatter.Test/SAX.Formatter.Test.csproj
@@ -37,7 +37,7 @@
 
     <ItemGroup Label="package dependencies">
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />

--- a/Tests/SAX.TokenParser.Test/SAX.TokenParser.Test.csproj
+++ b/Tests/SAX.TokenParser.Test/SAX.TokenParser.Test.csproj
@@ -37,7 +37,7 @@
 
   <ItemGroup Label="package dependencies">
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />

--- a/Tests/SAX.Tokenizer.Negative.Test/SAX.Tokenizer.Negative.Test.csproj
+++ b/Tests/SAX.Tokenizer.Negative.Test/SAX.Tokenizer.Negative.Test.csproj
@@ -22,11 +22,6 @@
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == ''">
-    <TargetFrameworkIdentifier>.NETCoreApp</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>9.0</TargetFrameworkVersion>
-  </PropertyGroup>
-
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
@@ -37,7 +32,7 @@
 
   <ItemGroup Label="package dependencies">
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />

--- a/Tests/SAX.Tokenizer.Test/SAX.Tokenizer.Test.csproj
+++ b/Tests/SAX.Tokenizer.Test/SAX.Tokenizer.Test.csproj
@@ -37,7 +37,7 @@
 
   <ItemGroup Label="package dependencies">
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit.v3" />
+    <PackageReference Include="xunit.v3.mtp-v2" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" />

--- a/Tests/XmlFormat.Test.Assets/XmlFormat.Test.Assets.csproj
+++ b/Tests/XmlFormat.Test.Assets/XmlFormat.Test.Assets.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup Label="package dependencies">
-    <PackageReference Include=" xunit.v3.assert" />
+    <PackageReference Include="xunit.v3.assert" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- **build: replace package reference 'xunit.v3' with 'xunit.v3.mtp-v2' v3.2.3**
- **build(MsBuild.Task.Test): replace package reference 'xunit.v3' with 'xunit.v3.mtp-v2'**
- **build(ReadOnlySpan.Extensions.Test): replace package reference 'xunit.v3' with 'xunit.v3.mtp-v2'**
- **build(SAX.EventHandler.Test): replace package reference 'xunit.v3' with 'xunit.v3.mtp-v2'**
- **build(SAX.Formatter.Test): replace package reference 'xunit.v3' with 'xunit.v3.mtp-v2'**
- **build(SAX.TokenParser.Test): replace package reference 'xunit.v3' with 'xunit.v3.mtp-v2'**
- **build(SAX.Tokenizer.Negative.Test): replace package reference 'xunit.v3' with 'xunit.v3.mtp-v2'**
- **build(SAX.Tokenizer.Test): replace package reference 'xunit.v3' with 'xunit.v3.mtp-v2'**
- **build(XmlFormat.Test.Assets): remove whitespace from package reference 'xunit.v3.assert'**
